### PR TITLE
Improve dynamic mobile layout scaling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,6 +1,17 @@
 :root {
   --scale: 1;
+  --font-scale: 1;
+  --spacing-scale: 1;
+  --radius-scale: 1;
   --base-font-size: 16px;
+  --space-unit-base: 1rem;
+  --space-unit: calc(var(--space-unit-base) * var(--spacing-scale));
+  --space-xs: calc(var(--space-unit) * 0.65);
+  --space-sm: calc(var(--space-unit) * 0.85);
+  --space-md: var(--space-unit);
+  --space-lg: calc(var(--space-unit) * 1.5);
+  --space-xl: calc(var(--space-unit) * 2.1);
+  --space-xxl: calc(var(--space-unit) * 2.8);
   --layout-max-width: 520px;
   --bg: #030712;
   --bg-gradient: radial-gradient(circle at 20% -10%, rgba(13, 148, 136, 0.25), transparent 55%),
@@ -16,14 +27,22 @@
   --text-secondary: #cbd5f5;
   --text-muted: #94a3b8;
   --shadow-soft: 0 28px 60px rgba(2, 6, 23, 0.55);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  --radius-lg-base: 28px;
+  --radius-md-base: 18px;
+  --radius-sm-base: 12px;
+  --radius-lg: calc(var(--radius-lg-base) * var(--radius-scale));
+  --radius-md: calc(var(--radius-md-base) * var(--radius-scale));
+  --radius-sm: calc(var(--radius-sm-base) * var(--radius-scale));
+  --nav-height: 64px;
+  --viewport-inset-top: 0px;
+  --viewport-inset-right: 0px;
+  --viewport-inset-bottom: 0px;
+  --viewport-inset-left: 0px;
   --font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 html {
-  font-size: calc(var(--base-font-size) * var(--scale));
+  font-size: calc(var(--base-font-size) * var(--scale) * var(--font-scale));
 }
 
 * {
@@ -38,8 +57,10 @@ body {
   background: var(--bg-gradient);
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
-  padding: max(env(safe-area-inset-top), 0px) max(env(safe-area-inset-right), 0px)
-    max(env(safe-area-inset-bottom), 0px) max(env(safe-area-inset-left), 0px);
+  padding: calc(max(env(safe-area-inset-top), 0px) + var(--viewport-inset-top))
+    calc(max(env(safe-area-inset-right), 0px) + var(--viewport-inset-right))
+    calc(max(env(safe-area-inset-bottom), 0px) + var(--viewport-inset-bottom))
+    calc(max(env(safe-area-inset-left), 0px) + var(--viewport-inset-left));
 }
 
 .page {
@@ -49,6 +70,7 @@ body {
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
+  padding-bottom: calc(var(--nav-height) + var(--space-sm));
 }
 
 a {
@@ -63,7 +85,8 @@ a:focus {
 
 .hero {
   position: relative;
-  padding: 3.25rem 1.6rem 2.5rem;
+  padding: calc(3.25rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(2.5rem * var(--spacing-scale));
   overflow: hidden;
 }
 
@@ -78,17 +101,17 @@ a:focus {
 .hero__container {
   position: relative;
   display: grid;
-  gap: 2.4rem;
+  gap: calc(2.4rem * var(--spacing-scale));
 }
 
 .hero__content {
   display: grid;
-  gap: 0.9rem;
+  gap: calc(0.9rem * var(--spacing-scale));
 }
 
 .hero__eyebrow {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.24em;
   text-transform: uppercase;
   color: var(--accent-strong);
@@ -96,27 +119,47 @@ a:focus {
 
 .hero__title {
   margin: 0;
-  font-size: clamp(2.35rem, 9vw, 3rem);
+  font-size: calc(clamp(2.35rem, 9vw, 3rem) * var(--font-scale));
   line-height: 1.08;
   font-weight: 700;
 }
 
 .hero__description {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: calc(1.02rem * var(--font-scale));
   line-height: 1.65;
   color: var(--text-secondary);
 }
 
+.hero__meta {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: calc(0.86rem * var(--font-scale));
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.hero__meta::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: radial-gradient(circle at 50% 40%, var(--accent-strong), rgba(14, 165, 233, 0.25));
+  box-shadow: 0 0 12px rgba(14, 165, 233, 0.4);
+}
+
 .hero__visual {
   margin: 0;
-  padding: 1.2rem;
+  padding: calc(1.2rem * var(--spacing-scale));
   border-radius: var(--radius-lg);
   border: 1px solid rgba(56, 189, 248, 0.25);
   background: var(--surface);
   box-shadow: var(--shadow-soft);
   display: grid;
-  gap: 0.85rem;
+  gap: calc(0.85rem * var(--spacing-scale));
 }
 
 .hero__visual canvas {
@@ -126,12 +169,12 @@ a:focus {
   display: block;
   border-radius: var(--radius-md);
   background: rgba(148, 163, 184, 0.08);
-  max-height: calc(var(--viewport-height, 100vh) * 0.34);
+  max-height: clamp(220px, calc(var(--viewport-height, 100vh) * 0.34), 380px);
 }
 
 .hero__hint {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -141,14 +184,16 @@ a:focus {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2.3rem;
-  padding: 0 1.6rem 3.5rem;
+  gap: calc(2.3rem * var(--spacing-scale));
+  padding: 0 calc(1.6rem * var(--spacing-scale))
+    calc(3.5rem * var(--spacing-scale) + var(--nav-height));
 }
 
 .panel {
   background: var(--surface-alt);
   border-radius: var(--radius-lg);
-  padding: 1.8rem 1.6rem 1.8rem;
+  padding: calc(1.8rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(1.8rem * var(--spacing-scale));
   border: 1px solid var(--border);
   box-shadow: 0 18px 35px rgba(8, 15, 40, 0.42);
   backdrop-filter: blur(18px);
@@ -156,18 +201,18 @@ a:focus {
 
 .panel__header {
   display: grid;
-  gap: 0.55rem;
-  margin-bottom: 1.6rem;
+  gap: calc(0.55rem * var(--spacing-scale));
+  margin-bottom: calc(1.6rem * var(--spacing-scale));
 }
 
 .panel__title {
   margin: 0;
-  font-size: clamp(1.4rem, 1.28rem + 0.9vw, 1.85rem);
+  font-size: calc(clamp(1.4rem, 1.28rem + 0.9vw, 1.85rem) * var(--font-scale));
   letter-spacing: 0.02em;
 }
 
 .panel__subtitle {
-  font-size: clamp(0.72rem, 0.68rem + 0.28vw, 0.85rem);
+  font-size: calc(clamp(0.72rem, 0.68rem + 0.28vw, 0.85rem) * var(--font-scale));
   text-transform: uppercase;
   letter-spacing: 0.18em;
   color: var(--text-muted);
@@ -175,16 +220,16 @@ a:focus {
 
 .card-grid {
   display: grid;
-  gap: 1.1rem;
+  gap: calc(1.1rem * var(--spacing-scale));
 }
 
 .day-card {
   background: rgba(15, 23, 42, 0.85);
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.22);
-  padding: 1.2rem 1.1rem;
+  padding: calc(1.2rem * var(--spacing-scale)) calc(1.1rem * var(--spacing-scale));
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
   position: relative;
   overflow: hidden;
   transition: border-color 160ms ease, transform 160ms ease;
@@ -218,11 +263,11 @@ a:focus {
 
 .day-card-content {
   display: grid;
-  gap: 0.85rem;
+  gap: calc(0.85rem * var(--spacing-scale));
 }
 
 .day-label {
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -230,13 +275,13 @@ a:focus {
 
 .winner {
   display: grid;
-  gap: 0.35rem;
-  font-size: clamp(1.1rem, 1.02rem + 0.6vw, 1.32rem);
+  gap: calc(0.35rem * var(--spacing-scale));
+  font-size: calc(clamp(1.1rem, 1.02rem + 0.6vw, 1.32rem) * var(--font-scale));
   font-weight: 600;
 }
 
 .winner span {
-  font-size: clamp(0.82rem, 0.78rem + 0.2vw, 0.92rem);
+  font-size: calc(clamp(0.82rem, 0.78rem + 0.2vw, 0.92rem) * var(--font-scale));
   color: var(--text-muted);
 }
 
@@ -246,14 +291,15 @@ a:focus {
   background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(14, 165, 233, 0.08));
   color: var(--text-primary);
   border-radius: 999px;
-  padding: clamp(0.6rem, 0.54rem + 0.5vw, 0.85rem) clamp(1rem, 0.9rem + 1vw, 1.4rem);
-  font-size: clamp(0.92rem, 0.82rem + 0.6vw, 1.08rem);
+  padding: calc(clamp(0.6rem, 0.54rem + 0.5vw, 0.85rem) * var(--spacing-scale))
+    calc(clamp(1rem, 0.9rem + 1vw, 1.4rem) * var(--spacing-scale));
+  font-size: calc(clamp(0.92rem, 0.82rem + 0.6vw, 1.08rem) * var(--font-scale));
   font-weight: 600;
   letter-spacing: 0.04em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
+  gap: calc(0.45rem * var(--spacing-scale));
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease;
   width: 100%;
@@ -295,25 +341,25 @@ a:focus {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.7rem;
+  gap: calc(0.7rem * var(--spacing-scale));
 }
 
 .player-list li {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.85rem 0.95rem;
+  gap: calc(0.75rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale)) calc(0.95rem * var(--spacing-scale));
   border-radius: var(--radius-sm);
   background: rgba(2, 6, 23, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.18);
-  font-size: clamp(0.92rem, 0.88rem + 0.28vw, 1.06rem);
+  font-size: calc(clamp(0.92rem, 0.88rem + 0.28vw, 1.06rem) * var(--font-scale));
 }
 
 .player-name {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: calc(0.55rem * var(--spacing-scale));
   font-weight: 500;
 }
 
@@ -329,22 +375,22 @@ a:focus {
 
 .search-panel {
   display: grid;
-  gap: 1.4rem;
+  gap: calc(1.4rem * var(--spacing-scale));
   background: rgba(15, 23, 42, 0.82);
-  padding: 1.4rem 1.2rem;
+  padding: calc(1.4rem * var(--spacing-scale)) calc(1.2rem * var(--spacing-scale));
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .search-controls {
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
 }
 
 .search-controls label {
   display: grid;
-  gap: 0.5rem;
-  font-size: clamp(0.76rem, 0.72rem + 0.25vw, 0.88rem);
+  gap: calc(0.5rem * var(--spacing-scale));
+  font-size: calc(clamp(0.76rem, 0.72rem + 0.25vw, 0.88rem) * var(--font-scale));
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -353,12 +399,13 @@ a:focus {
 .search-controls input,
 .search-controls select {
   width: 100%;
-  padding: clamp(0.72rem, 0.68rem + 0.4vw, 0.95rem) clamp(0.9rem, 0.82rem + 0.7vw, 1.25rem);
+  padding: calc(clamp(0.72rem, 0.68rem + 0.4vw, 0.95rem) * var(--spacing-scale))
+    calc(clamp(0.9rem, 0.82rem + 0.7vw, 1.25rem) * var(--spacing-scale));
   border-radius: var(--radius-sm);
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(2, 6, 23, 0.82);
   color: var(--text-primary);
-  font-size: clamp(0.98rem, 0.94rem + 0.35vw, 1.1rem);
+  font-size: calc(clamp(0.98rem, 0.94rem + 0.35vw, 1.1rem) * var(--font-scale));
   transition: border-color 140ms ease, box-shadow 140ms ease;
 }
 
@@ -371,13 +418,13 @@ a:focus {
 
 .player-results {
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
 }
 
 .player-result-card {
   display: grid;
-  gap: 0.85rem;
-  padding: 1.1rem 1.15rem;
+  gap: calc(0.85rem * var(--spacing-scale));
+  padding: calc(1.1rem * var(--spacing-scale)) calc(1.15rem * var(--spacing-scale));
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(2, 6, 23, 0.7);
@@ -385,21 +432,21 @@ a:focus {
 
 .player-result-card .meta {
   display: grid;
-  gap: 0.4rem;
+  gap: calc(0.4rem * var(--spacing-scale));
 }
 
 .player-result-card strong {
-  font-size: clamp(1.05rem, 1rem + 0.4vw, 1.2rem);
+  font-size: calc(clamp(1.05rem, 1rem + 0.4vw, 1.2rem) * var(--font-scale));
   letter-spacing: 0.01em;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.75rem;
+  gap: calc(0.45rem * var(--spacing-scale));
+  padding: calc(0.35rem * var(--spacing-scale)) calc(0.75rem * var(--spacing-scale));
   border-radius: 999px;
-  font-size: clamp(0.8rem, 0.76rem + 0.3vw, 0.92rem);
+  font-size: calc(clamp(0.8rem, 0.76rem + 0.3vw, 0.92rem) * var(--font-scale));
   font-weight: 600;
   background: rgba(56, 189, 248, 0.16);
   color: var(--accent-strong);
@@ -423,50 +470,132 @@ a:focus {
 }
 
 .page__footer {
-  padding: 2.5rem 1.6rem 3rem;
-  font-size: 0.85rem;
+  padding: calc(2.5rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(3rem * var(--spacing-scale));
+  font-size: calc(0.85rem * var(--font-scale));
   color: var(--text-muted);
   text-align: center;
 }
 
 .page__footer code {
   font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.82rem;
+  font-size: calc(0.82rem * var(--font-scale));
   background: rgba(2, 6, 23, 0.55);
-  padding: 0.15rem 0.35rem;
+  padding: calc(0.15rem * var(--spacing-scale)) calc(0.35rem * var(--spacing-scale));
   border-radius: 6px;
   border: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.mobile-nav {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--space-sm) + var(--viewport-inset-bottom));
+  transform: translateX(-50%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: calc(0.35rem * var(--spacing-scale));
+  padding: calc(0.4rem * var(--spacing-scale));
+  min-height: var(--nav-height);
+  width: min(var(--layout-max-width),
+      calc(100vw - var(--viewport-inset-left) - var(--viewport-inset-right) - var(--space-md)));
+  background: rgba(7, 12, 24, 0.86);
+  border-radius: calc(999px * var(--radius-scale));
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  box-shadow: 0 22px 45px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(18px);
+  isolation: isolate;
+  z-index: 40;
+}
+
+.mobile-nav__indicator {
+  position: absolute;
+  inset: calc(0.4rem * var(--spacing-scale));
+  width: calc((100% - calc(0.8rem * var(--spacing-scale))) / 3);
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  box-shadow: 0 8px 24px rgba(14, 165, 233, 0.35);
+  transition: transform 180ms ease, width 180ms ease;
+  pointer-events: none;
+  transform: translateX(0);
+  min-height: calc(var(--nav-height) - calc(0.8rem * var(--spacing-scale)));
+}
+
+.mobile-nav__button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: calc(0.2rem * var(--spacing-scale));
+  padding: calc(0.55rem * var(--spacing-scale)) 0;
+  border-radius: 999px;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+
+.mobile-nav__button:hover,
+.mobile-nav__button:focus-visible {
+  color: var(--text-primary);
+  outline: none;
+}
+
+.mobile-nav__button.is-active {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.mobile-nav__icon {
+  font-size: calc(1.05rem * var(--font-scale));
+  line-height: 1;
+}
+
+.mobile-nav__label {
+  font-size: calc(0.72rem * var(--font-scale));
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 @media (min-width: 560px) {
   :root {
     --layout-max-width: 540px;
+    --nav-height: 70px;
   }
 
   .hero {
-    padding: 3.6rem 2.4rem 2.8rem;
+    padding: calc(3.6rem * var(--spacing-scale)) calc(2.4rem * var(--spacing-scale))
+      calc(2.8rem * var(--spacing-scale));
   }
 
   .main {
-    padding: 0 2.4rem 4rem;
+    padding: 0 calc(2.4rem * var(--spacing-scale))
+      calc(4rem * var(--spacing-scale) + var(--nav-height));
   }
 
   .panel {
-    padding: 2rem 1.85rem 2.1rem;
+    padding: calc(2rem * var(--spacing-scale)) calc(1.85rem * var(--spacing-scale))
+      calc(2.1rem * var(--spacing-scale));
   }
 
   .search-panel {
-    padding: 1.6rem 1.45rem;
+    padding: calc(1.6rem * var(--spacing-scale)) calc(1.45rem * var(--spacing-scale));
   }
 }
 
 @media (min-width: 720px) {
   :root {
     --layout-max-width: 580px;
+    --nav-height: 72px;
   }
 
   .hero__container {
-    gap: 2.8rem;
+    gap: calc(2.8rem * var(--spacing-scale));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
             <p class="hero__description">
               Monitor daily winners, dive into complete leaderboards, and study player trajectories with an interface that measures your device and scales every element for a distortion-free mobile experience.
             </p>
+            <p id="device-meta" class="hero__meta" aria-live="polite">Calibrating layout for your screen…</p>
           </div>
           <figure class="hero__visual">
             <canvas
@@ -89,6 +90,22 @@
           </div>
         </section>
       </main>
+
+      <nav class="mobile-nav" aria-label="Quick mobile navigation">
+        <span class="mobile-nav__indicator" aria-hidden="true"></span>
+        <button type="button" class="mobile-nav__button" data-nav-target="open-stats">
+          <span aria-hidden="true" class="mobile-nav__icon">📊</span>
+          <span class="mobile-nav__label">Open stats</span>
+        </button>
+        <button type="button" class="mobile-nav__button" data-nav-target="player-stats">
+          <span aria-hidden="true" class="mobile-nav__icon">🏅</span>
+          <span class="mobile-nav__label">Player stats</span>
+        </button>
+        <button type="button" class="mobile-nav__button" data-nav-action="scroll-top">
+          <span aria-hidden="true" class="mobile-nav__icon">⬆️</span>
+          <span class="mobile-nav__label">Top</span>
+        </button>
+      </nav>
 
       <footer class="page__footer">
         Data refreshes daily. Keep <code>day_stats.json</code> in sync on GitHub to surface the latest runs.


### PR DESCRIPTION
## Summary
- calculate viewport metrics with visualViewport to drive adaptive scales, safe-area insets, and device readout
- refresh spacing/typography tokens and component paddings in CSS using scaling variables and add a fixed quick navigation bar
- expose the device calibration meta line in the hero and wire up a smooth-scrolling bottom navigation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc5270e564832f80a0606a99575e7e