### PR TITLE
Stabilize viewport scaling across devices

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,9 @@
 :root {
   --scale: 1;
+  --font-scale: 1;
+  --spacing-scale: 1;
+  --radius-scale: 1;
+  --elevation-scale: 1;
   --base-font-size: 16px;
   --layout-max-width: 520px;
   --bg: #030712;
@@ -15,15 +19,15 @@
   --text-primary: #f8fafc;
   --text-secondary: #cbd5f5;
   --text-muted: #94a3b8;
-  --shadow-soft: 0 28px 60px rgba(2, 6, 23, 0.55);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  --shadow-soft: 0 calc(28px * var(--elevation-scale)) calc(60px * var(--elevation-scale)) rgba(2, 6, 23, 0.55);
+  --radius-lg: calc(28px * var(--radius-scale));
+  --radius-md: calc(18px * var(--radius-scale));
+  --radius-sm: calc(12px * var(--radius-scale));
   --font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 html {
-  font-size: calc(var(--base-font-size) * var(--scale));
+  font-size: calc(var(--base-font-size) * var(--font-scale));
 }
 
 * {
@@ -40,6 +44,13 @@ body {
   -webkit-font-smoothing: antialiased;
   padding: max(env(safe-area-inset-top), 0px) max(env(safe-area-inset-right), 0px)
     max(env(safe-area-inset-bottom), 0px) max(env(safe-area-inset-left), 0px);
+}
+
+html,
+body {
+  width: 100%;
+  overflow-x: hidden;
+  overscroll-behavior-x: none;
 }
 
 .page {
@@ -63,7 +74,8 @@ a:focus {
 
 .hero {
   position: relative;
-  padding: 3.25rem 1.6rem 2.5rem;
+  padding: calc(3.25rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(2.5rem * var(--spacing-scale));
   overflow: hidden;
 }
 
@@ -78,17 +90,17 @@ a:focus {
 .hero__container {
   position: relative;
   display: grid;
-  gap: 2.4rem;
+  gap: calc(2.4rem * var(--spacing-scale));
 }
 
 .hero__content {
   display: grid;
-  gap: 0.9rem;
+  gap: calc(0.9rem * var(--spacing-scale));
 }
 
 .hero__eyebrow {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.24em;
   text-transform: uppercase;
   color: var(--accent-strong);
@@ -96,27 +108,28 @@ a:focus {
 
 .hero__title {
   margin: 0;
-  font-size: clamp(2.35rem, 9vw, 3rem);
+  font-size: clamp(calc(2.35rem * var(--font-scale)), calc(9vw * var(--font-scale)),
+      calc(3rem * var(--font-scale)));
   line-height: 1.08;
   font-weight: 700;
 }
 
 .hero__description {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: calc(1.02rem * var(--font-scale));
   line-height: 1.65;
   color: var(--text-secondary);
 }
 
 .hero__visual {
   margin: 0;
-  padding: 1.2rem;
+  padding: calc(1.2rem * var(--spacing-scale));
   border-radius: var(--radius-lg);
   border: 1px solid rgba(56, 189, 248, 0.25);
   background: var(--surface);
   box-shadow: var(--shadow-soft);
   display: grid;
-  gap: 0.85rem;
+  gap: calc(0.85rem * var(--spacing-scale));
 }
 
 .hero__visual canvas {
@@ -131,43 +144,116 @@ a:focus {
 
 .hero__hint {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.quick-nav {
+  position: sticky;
+  top: calc(env(safe-area-inset-top) + calc(0.75rem * var(--spacing-scale)));
+  z-index: 15;
+  display: flex;
+  justify-content: center;
+  padding: 0 calc(1.2rem * var(--spacing-scale));
+  margin: calc(-1.2rem * var(--spacing-scale)) 0 calc(1.6rem * var(--spacing-scale));
+}
+
+.quick-nav__container {
+  width: 100%;
+  max-width: var(--layout-max-width, 520px);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(calc(7.5rem * var(--spacing-scale)), 1fr));
+  gap: calc(0.6rem * var(--spacing-scale));
+  padding: calc(0.75rem * var(--spacing-scale));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(8, 15, 35, 0.78);
+  backdrop-filter: blur(calc(16px * var(--elevation-scale)));
+  box-shadow: 0 calc(16px * var(--elevation-scale)) calc(28px * var(--elevation-scale))
+    rgba(8, 15, 40, 0.32);
+}
+
+.quick-nav__button {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.16), rgba(14, 165, 233, 0.04));
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: calc(0.65rem * var(--spacing-scale)) calc(1rem * var(--spacing-scale));
+  font-size: clamp(calc(0.78rem * var(--font-scale)),
+      calc((0.74rem + 0.2vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(0.35rem * var(--spacing-scale));
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease,
+    color 160ms ease;
+  touch-action: manipulation;
+}
+
+.quick-nav__button:hover,
+.quick-nav__button:focus-visible {
+  border-color: rgba(56, 189, 248, 0.5);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(56, 189, 248, 0.08));
+  color: var(--text-primary);
+  transform: translateY(calc(-1px * var(--spacing-scale)));
+  outline: none;
+  box-shadow: 0 0 0 calc(2px * var(--spacing-scale)) rgba(14, 165, 233, 0.25);
+}
+
+.quick-nav__button[aria-pressed='true'] {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(14, 165, 233, 0.15));
+  color: var(--text-primary);
+  box-shadow: 0 calc(8px * var(--elevation-scale)) calc(18px * var(--elevation-scale))
+    rgba(14, 165, 233, 0.32);
+}
+
+.quick-nav__button:active {
+  transform: translateY(0);
 }
 
 .main {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2.3rem;
-  padding: 0 1.6rem 3.5rem;
+  gap: calc(2.3rem * var(--spacing-scale));
+  padding: 0 calc(1.6rem * var(--spacing-scale)) calc(3.5rem * var(--spacing-scale));
 }
 
 .panel {
   background: var(--surface-alt);
   border-radius: var(--radius-lg);
-  padding: 1.8rem 1.6rem 1.8rem;
+  padding: calc(1.8rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(1.8rem * var(--spacing-scale));
   border: 1px solid var(--border);
-  box-shadow: 0 18px 35px rgba(8, 15, 40, 0.42);
-  backdrop-filter: blur(18px);
+  box-shadow: 0 calc(18px * var(--elevation-scale)) calc(35px * var(--elevation-scale))
+    rgba(8, 15, 40, 0.42);
+  backdrop-filter: blur(calc(18px * var(--elevation-scale)));
 }
 
 .panel__header {
   display: grid;
-  gap: 0.55rem;
-  margin-bottom: 1.6rem;
+  gap: calc(0.55rem * var(--spacing-scale));
+  margin-bottom: calc(1.6rem * var(--spacing-scale));
 }
 
 .panel__title {
   margin: 0;
-  font-size: clamp(1.4rem, 1.28rem + 0.9vw, 1.85rem);
+  font-size: clamp(calc(1.4rem * var(--font-scale)), calc((1.28rem + 0.9vw) * var(--font-scale)),
+      calc(1.85rem * var(--font-scale)));
   letter-spacing: 0.02em;
 }
 
 .panel__subtitle {
-  font-size: clamp(0.72rem, 0.68rem + 0.28vw, 0.85rem);
+  font-size: clamp(calc(0.72rem * var(--font-scale)),
+      calc((0.68rem + 0.28vw) * var(--font-scale)), calc(0.85rem * var(--font-scale)));
   text-transform: uppercase;
   letter-spacing: 0.18em;
   color: var(--text-muted);
@@ -175,16 +261,16 @@ a:focus {
 
 .card-grid {
   display: grid;
-  gap: 1.1rem;
+  gap: calc(1.1rem * var(--spacing-scale));
 }
 
 .day-card {
   background: rgba(15, 23, 42, 0.85);
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.22);
-  padding: 1.2rem 1.1rem;
+  padding: calc(1.2rem * var(--spacing-scale)) calc(1.1rem * var(--spacing-scale));
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
   position: relative;
   overflow: hidden;
   transition: border-color 160ms ease, transform 160ms ease;
@@ -218,11 +304,11 @@ a:focus {
 
 .day-card-content {
   display: grid;
-  gap: 0.85rem;
+  gap: calc(0.85rem * var(--spacing-scale));
 }
 
 .day-label {
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--font-scale));
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -230,13 +316,15 @@ a:focus {
 
 .winner {
   display: grid;
-  gap: 0.35rem;
-  font-size: clamp(1.1rem, 1.02rem + 0.6vw, 1.32rem);
+  gap: calc(0.35rem * var(--spacing-scale));
+  font-size: clamp(calc(1.1rem * var(--font-scale)),
+      calc((1.02rem + 0.6vw) * var(--font-scale)), calc(1.32rem * var(--font-scale)));
   font-weight: 600;
 }
 
 .winner span {
-  font-size: clamp(0.82rem, 0.78rem + 0.2vw, 0.92rem);
+  font-size: clamp(calc(0.82rem * var(--font-scale)),
+      calc((0.78rem + 0.2vw) * var(--font-scale)), calc(0.92rem * var(--font-scale)));
   color: var(--text-muted);
 }
 
@@ -246,14 +334,19 @@ a:focus {
   background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(14, 165, 233, 0.08));
   color: var(--text-primary);
   border-radius: 999px;
-  padding: clamp(0.6rem, 0.54rem + 0.5vw, 0.85rem) clamp(1rem, 0.9rem + 1vw, 1.4rem);
-  font-size: clamp(0.92rem, 0.82rem + 0.6vw, 1.08rem);
+  padding: clamp(calc(0.6rem * var(--spacing-scale)),
+      calc((0.54rem + 0.5vw) * var(--spacing-scale)),
+      calc(0.85rem * var(--spacing-scale)))
+    clamp(calc(1rem * var(--spacing-scale)), calc((0.9rem + 1vw) * var(--spacing-scale)),
+      calc(1.4rem * var(--spacing-scale)));
+  font-size: clamp(calc(0.92rem * var(--font-scale)),
+      calc((0.82rem + 0.6vw) * var(--font-scale)), calc(1.08rem * var(--font-scale)));
   font-weight: 600;
   letter-spacing: 0.04em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
+  gap: calc(0.45rem * var(--spacing-scale));
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease;
   width: 100%;
@@ -261,7 +354,7 @@ a:focus {
 
 .details-button::after {
   content: '›';
-  font-size: 1.2rem;
+  font-size: calc(1.2rem * var(--font-scale));
   line-height: 1;
   transition: transform 160ms ease;
 }
@@ -280,7 +373,7 @@ a:focus {
 .collapse {
   display: none;
   opacity: 0;
-  transform: translateY(-6px);
+  transform: translateY(calc(-6px * var(--spacing-scale)));
   transition: opacity 180ms ease, transform 180ms ease;
 }
 
@@ -295,25 +388,26 @@ a:focus {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.7rem;
+  gap: calc(0.7rem * var(--spacing-scale));
 }
 
 .player-list li {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.85rem 0.95rem;
+  gap: calc(0.75rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale)) calc(0.95rem * var(--spacing-scale));
   border-radius: var(--radius-sm);
   background: rgba(2, 6, 23, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.18);
-  font-size: clamp(0.92rem, 0.88rem + 0.28vw, 1.06rem);
+  font-size: clamp(calc(0.92rem * var(--font-scale)),
+      calc((0.88rem + 0.28vw) * var(--font-scale)), calc(1.06rem * var(--font-scale)));
 }
 
 .player-name {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: calc(0.55rem * var(--spacing-scale));
   font-weight: 500;
 }
 
@@ -329,22 +423,23 @@ a:focus {
 
 .search-panel {
   display: grid;
-  gap: 1.4rem;
+  gap: calc(1.4rem * var(--spacing-scale));
   background: rgba(15, 23, 42, 0.82);
-  padding: 1.4rem 1.2rem;
+  padding: calc(1.4rem * var(--spacing-scale)) calc(1.2rem * var(--spacing-scale));
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .search-controls {
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
 }
 
 .search-controls label {
   display: grid;
-  gap: 0.5rem;
-  font-size: clamp(0.76rem, 0.72rem + 0.25vw, 0.88rem);
+  gap: calc(0.5rem * var(--spacing-scale));
+  font-size: clamp(calc(0.76rem * var(--font-scale)),
+      calc((0.72rem + 0.25vw) * var(--font-scale)), calc(0.88rem * var(--font-scale)));
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -353,12 +448,17 @@ a:focus {
 .search-controls input,
 .search-controls select {
   width: 100%;
-  padding: clamp(0.72rem, 0.68rem + 0.4vw, 0.95rem) clamp(0.9rem, 0.82rem + 0.7vw, 1.25rem);
+  padding: clamp(calc(0.72rem * var(--spacing-scale)),
+      calc((0.68rem + 0.4vw) * var(--spacing-scale)),
+      calc(0.95rem * var(--spacing-scale)))
+    clamp(calc(0.9rem * var(--spacing-scale)), calc((0.82rem + 0.7vw) * var(--spacing-scale)),
+      calc(1.25rem * var(--spacing-scale)));
   border-radius: var(--radius-sm);
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(2, 6, 23, 0.82);
   color: var(--text-primary);
-  font-size: clamp(0.98rem, 0.94rem + 0.35vw, 1.1rem);
+  font-size: clamp(calc(0.98rem * var(--font-scale)),
+      calc((0.94rem + 0.35vw) * var(--font-scale)), calc(1.1rem * var(--font-scale)));
   transition: border-color 140ms ease, box-shadow 140ms ease;
 }
 
@@ -371,13 +471,13 @@ a:focus {
 
 .player-results {
   display: grid;
-  gap: 1rem;
+  gap: calc(1rem * var(--spacing-scale));
 }
 
 .player-result-card {
   display: grid;
-  gap: 0.85rem;
-  padding: 1.1rem 1.15rem;
+  gap: calc(0.85rem * var(--spacing-scale));
+  padding: calc(1.1rem * var(--spacing-scale)) calc(1.15rem * var(--spacing-scale));
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(2, 6, 23, 0.7);
@@ -385,21 +485,23 @@ a:focus {
 
 .player-result-card .meta {
   display: grid;
-  gap: 0.4rem;
+  gap: calc(0.4rem * var(--spacing-scale));
 }
 
 .player-result-card strong {
-  font-size: clamp(1.05rem, 1rem + 0.4vw, 1.2rem);
+  font-size: clamp(calc(1.05rem * var(--font-scale)),
+      calc((1rem + 0.4vw) * var(--font-scale)), calc(1.2rem * var(--font-scale)));
   letter-spacing: 0.01em;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.75rem;
+  gap: calc(0.45rem * var(--spacing-scale));
+  padding: calc(0.35rem * var(--spacing-scale)) calc(0.75rem * var(--spacing-scale));
   border-radius: 999px;
-  font-size: clamp(0.8rem, 0.76rem + 0.3vw, 0.92rem);
+  font-size: clamp(calc(0.8rem * var(--font-scale)),
+      calc((0.76rem + 0.3vw) * var(--font-scale)), calc(0.92rem * var(--font-scale)));
   font-weight: 600;
   background: rgba(56, 189, 248, 0.16);
   color: var(--accent-strong);
@@ -423,18 +525,19 @@ a:focus {
 }
 
 .page__footer {
-  padding: 2.5rem 1.6rem 3rem;
-  font-size: 0.85rem;
+  padding: calc(2.5rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
+    calc(3rem * var(--spacing-scale));
+  font-size: calc(0.85rem * var(--font-scale));
   color: var(--text-muted);
   text-align: center;
 }
 
 .page__footer code {
   font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.82rem;
+  font-size: calc(0.82rem * var(--font-scale));
   background: rgba(2, 6, 23, 0.55);
-  padding: 0.15rem 0.35rem;
-  border-radius: 6px;
+  padding: calc(0.15rem * var(--spacing-scale)) calc(0.35rem * var(--spacing-scale));
+  border-radius: calc(6px * var(--radius-scale));
   border: 1px solid rgba(148, 163, 184, 0.24);
 }
 
@@ -444,19 +547,21 @@ a:focus {
   }
 
   .hero {
-    padding: 3.6rem 2.4rem 2.8rem;
+    padding: calc(3.6rem * var(--spacing-scale)) calc(2.4rem * var(--spacing-scale))
+      calc(2.8rem * var(--spacing-scale));
   }
 
   .main {
-    padding: 0 2.4rem 4rem;
+    padding: 0 calc(2.4rem * var(--spacing-scale)) calc(4rem * var(--spacing-scale));
   }
 
   .panel {
-    padding: 2rem 1.85rem 2.1rem;
+    padding: calc(2rem * var(--spacing-scale)) calc(1.85rem * var(--spacing-scale))
+      calc(2.1rem * var(--spacing-scale));
   }
 
   .search-panel {
-    padding: 1.6rem 1.45rem;
+    padding: calc(1.6rem * var(--spacing-scale)) calc(1.45rem * var(--spacing-scale));
   }
 }
 
@@ -466,7 +571,7 @@ a:focus {
   }
 
   .hero__container {
-    gap: 2.8rem;
+    gap: calc(2.8rem * var(--spacing-scale));
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,44 +8,203 @@ const playerSuggestions = document.getElementById('player-suggestions');
 const sortFieldSelect = document.getElementById('sort-field');
 const sortOrderSelect = document.getElementById('sort-order');
 const canvas = document.getElementById('statsCanvas');
+const quickNav = document.querySelector('.quick-nav');
+const quickNavButtons = quickNav
+  ? Array.from(quickNav.querySelectorAll('.quick-nav__button'))
+  : [];
 
 let playerIndex = new Map();
 let currentPlayer = null;
 let winnerTimeline = [];
 let canvasAnimationId = null;
 let canvasResizeHandler = null;
+let quickNavObserver = null;
+let metricsFrameId = null;
+let lastMetrics = null;
+
+function measureViewport() {
+  const viewport = window.visualViewport;
+  const doc = document.documentElement;
+  const screenWidth = window.screen?.width || 0;
+  const screenHeight = window.screen?.height || 0;
+  const fallbackWidth = window.innerWidth || doc.clientWidth || screenWidth || 0;
+  const fallbackHeight = window.innerHeight || doc.clientHeight || screenHeight || 0;
+
+  const width = viewport?.width ?? fallbackWidth;
+  const height = viewport?.height ?? fallbackHeight;
+
+  return {
+    width: Math.max(0, width || fallbackWidth),
+    height: Math.max(0, height || fallbackHeight),
+  };
+}
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
-function applyMobileMetrics() {
-  const width = Math.max(window.innerWidth || document.documentElement.clientWidth || 0, 320);
-  const height = Math.max(window.innerHeight || document.documentElement.clientHeight || 0, 540);
+function applyMobileMetrics({ force = false } = {}) {
+  const { width: measuredWidth, height: measuredHeight } = measureViewport();
+  const roundedWidth = Math.round(measuredWidth);
+  const roundedHeight = Math.round(measuredHeight);
+  const width = clamp(roundedWidth, 280, 1100);
+  const height = clamp(roundedHeight, 400, 1800);
+  const minDimension = Math.min(width, height);
+  const maxDimension = Math.max(width, height);
+  const pixelRatio = window.devicePixelRatio || 1;
+  const orientation = width >= height ? 'landscape' : 'portrait';
+
+  if (lastMetrics) {
+    const widthDelta = Math.abs(width - lastMetrics.width);
+    const heightDelta = Math.abs(height - lastMetrics.height);
+    const orientationChanged = orientation !== lastMetrics.orientation;
+    const widthChanged = widthDelta >= 4;
+    const heightChanged = heightDelta >= 32;
+    if (!force && !orientationChanged && !widthChanged && !heightChanged) {
+      return;
+    }
+  }
+
   const baseWidth = 390;
   const baseHeight = 844;
+  const baseDiagonal = Math.hypot(baseWidth, baseHeight);
+  const diagonal = Math.hypot(width, height);
   const widthScale = width / baseWidth;
   const heightScale = height / baseHeight;
-  const blendScale = widthScale * 0.65 + heightScale * 0.35;
-  const scale = clamp(blendScale, 0.85, 1.2);
-  const layoutWidth = clamp(width * 0.94, 320, 620);
+  const diagonalScale = diagonal / baseDiagonal;
+  const averagedScale = (widthScale + heightScale + diagonalScale) / 3;
+  const densityCompensation = clamp(Math.sqrt(pixelRatio) / 1.5, 0.7, 1.12);
+  const fontScale = clamp(averagedScale / densityCompensation, 0.8, 1.28);
+  const spacingScale = clamp(averagedScale * (orientation === 'landscape' ? 0.9 : 1.05), 0.7, 1.36);
+  const radiusScale = clamp(averagedScale * 0.9, 0.66, 1.22);
+  const elevationScale = clamp(averagedScale * (orientation === 'landscape' ? 0.84 : 1.1), 0.74, 1.36);
+  const layoutTarget = width * (orientation === 'landscape' ? 0.82 : 0.94);
+  const layoutWidth = Math.min(clamp(layoutTarget, 260, 720), width);
 
-  root.style.setProperty('--scale', scale.toFixed(4));
-  root.style.setProperty('--layout-max-width', `${layoutWidth}px`);
-  root.style.setProperty('--viewport-width', `${width}px`);
-  root.style.setProperty('--viewport-height', `${height}px`);
+  lastMetrics = { width, height, orientation };
+
+  root.style.setProperty('--scale', fontScale.toFixed(4));
+  root.style.setProperty('--font-scale', fontScale.toFixed(4));
+  root.style.setProperty('--spacing-scale', spacingScale.toFixed(4));
+  root.style.setProperty('--radius-scale', radiusScale.toFixed(4));
+  root.style.setProperty('--elevation-scale', elevationScale.toFixed(4));
+  root.style.setProperty('--layout-max-width', `${layoutWidth.toFixed(2)}px`);
+  root.style.setProperty('--viewport-width', `${width.toFixed(2)}px`);
+  root.style.setProperty('--viewport-height', `${height.toFixed(2)}px`);
+  root.style.setProperty('--viewport-min', `${minDimension.toFixed(2)}px`);
+  root.style.setProperty('--viewport-max', `${maxDimension.toFixed(2)}px`);
+  root.style.setProperty('--pixel-ratio', pixelRatio.toFixed(3));
   root.style.setProperty('--vh', `${height * 0.01}px`);
   root.style.setProperty('--vw', `${width * 0.01}px`);
 }
 
-applyMobileMetrics();
-window.addEventListener('resize', applyMobileMetrics, { passive: true });
-window.addEventListener('orientationchange', () => {
-  applyMobileMetrics();
-  if (typeof canvasResizeHandler === 'function') {
-    requestAnimationFrame(() => canvasResizeHandler());
+function scheduleMobileMetricsUpdate({ force = false } = {}) {
+  if (metricsFrameId) {
+    return;
   }
-});
+  metricsFrameId = requestAnimationFrame(() => {
+    metricsFrameId = null;
+    applyMobileMetrics({ force });
+  });
+}
+
+applyMobileMetrics({ force: true });
+window.addEventListener(
+  'resize',
+  () => {
+    scheduleMobileMetricsUpdate();
+  },
+  { passive: true },
+);
+window.addEventListener(
+  'orientationchange',
+  () => {
+    lastMetrics = null;
+    scheduleMobileMetricsUpdate({ force: true });
+  },
+  { passive: true },
+);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener(
+    'resize',
+    () => {
+      scheduleMobileMetricsUpdate();
+    },
+    { passive: true },
+  );
+}
+
+function setActiveQuickNav(targetId) {
+  if (!quickNavButtons.length) {
+    return;
+  }
+  quickNavButtons.forEach((button) => {
+    const isActive = button.dataset.scrollTarget === targetId;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function setupQuickNav() {
+  if (!quickNav || !quickNavButtons.length) {
+    return;
+  }
+
+  quickNav.addEventListener('click', (event) => {
+    const button = event.target.closest('.quick-nav__button');
+    if (!button) {
+      return;
+    }
+    const targetId = button.dataset.scrollTarget;
+    const target = targetId ? document.getElementById(targetId) : null;
+    if (!target) {
+      return;
+    }
+
+    const navHeight = quickNav.getBoundingClientRect().height;
+    const spacingScale = parseFloat(getComputedStyle(root).getPropertyValue('--spacing-scale')) || 1;
+    const topOffset = navHeight + 12 * spacingScale;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const behavior = prefersReducedMotion ? 'auto' : 'smooth';
+    const targetBounds = target.getBoundingClientRect();
+    const absoluteTop = (window.pageYOffset || document.documentElement.scrollTop || 0) + targetBounds.top;
+    const finalTop = Math.max(absoluteTop - topOffset, 0);
+
+    window.scrollTo({ top: finalTop, behavior });
+    setActiveQuickNav(targetId);
+  });
+
+  const observedSections = quickNavButtons
+    .map((button) => document.getElementById(button.dataset.scrollTarget || ''))
+    .filter(Boolean);
+
+  if (quickNavObserver) {
+    quickNavObserver.disconnect();
+  }
+
+  if (observedSections.length) {
+    setActiveQuickNav(observedSections[0].id);
+    quickNavObserver = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+        if (!visibleEntries.length) {
+          return;
+        }
+        const topEntry = visibleEntries[0];
+        setActiveQuickNav(topEntry.target.id);
+      },
+      {
+        rootMargin: '-48% 0px -46% 0px',
+        threshold: [0.25, 0.5, 0.75],
+      },
+    );
+
+    observedSections.forEach((section) => quickNavObserver.observe(section));
+  }
+}
+
+setupQuickNav();
 
 async function loadStats() {
   try {
@@ -315,6 +474,10 @@ function startCanvasAnimation() {
 
   if (canvasResizeHandler) {
     window.removeEventListener('resize', canvasResizeHandler);
+    if (window.visualViewport) {
+      window.visualViewport.removeEventListener('resize', canvasResizeHandler);
+      window.visualViewport.removeEventListener('scroll', canvasResizeHandler);
+    }
     canvasResizeHandler = null;
   }
 
@@ -333,6 +496,7 @@ function startCanvasAnimation() {
   let padding = 24;
   let stepX = 0;
   let start = null;
+  let labelFontSize = 14;
 
   function configureDimensions() {
     const parentWidth = canvas.parentElement?.clientWidth || window.innerWidth || 360;
@@ -340,6 +504,8 @@ function startCanvasAnimation() {
     const layoutMax = parseFloat(styles.getPropertyValue('--layout-max-width')) || parentWidth;
     const viewportWidth = parseFloat(styles.getPropertyValue('--viewport-width')) || parentWidth;
     const viewportHeight = parseFloat(styles.getPropertyValue('--viewport-height')) || window.innerHeight || 640;
+    const spacingScale = parseFloat(styles.getPropertyValue('--spacing-scale')) || 1;
+    const fontScale = parseFloat(styles.getPropertyValue('--font-scale')) || 1;
     const maxWidth = Math.min(layoutMax, viewportWidth * 0.96);
     const cssWidth = Math.min(parentWidth, Math.max(280, maxWidth));
     const cssHeight = clamp(Math.round(cssWidth * 0.64), 200, Math.round(viewportHeight * 0.42));
@@ -353,8 +519,9 @@ function startCanvasAnimation() {
 
     width = cssWidth;
     height = cssHeight;
-    padding = Math.max(22, Math.round(cssWidth * 0.1));
+    padding = Math.max(Math.round(18 * spacingScale), Math.round(cssWidth * 0.1));
     stepX = dayCount > 1 ? (width - padding * 2) / (dayCount - 1) : 0;
+    labelFontSize = Math.round(clamp(14 * fontScale, 12, 18));
   }
 
   function mapY(seconds) {
@@ -444,7 +611,7 @@ function startCanvasAnimation() {
     ctx.fill();
 
     ctx.fillStyle = 'rgba(255, 255, 255, 0.75)';
-    ctx.font = '14px Inter, sans-serif';
+    ctx.font = `${labelFontSize}px Inter, sans-serif`;
     ctx.fillText(`Day ${current.day} – ${current.name}`, padding, padding - 8);
 
     canvasAnimationId = requestAnimationFrame(drawFrame);
@@ -462,6 +629,10 @@ function startCanvasAnimation() {
   configureDimensions();
   canvasAnimationId = requestAnimationFrame(drawFrame);
   window.addEventListener('resize', canvasResizeHandler, { passive: true });
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', canvasResizeHandler, { passive: true });
+    window.visualViewport.addEventListener('scroll', canvasResizeHandler, { passive: true });
+  }
 }
 
 function parseTimeToSeconds(timeString) {

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   </head>
   <body>
     <div class="page">
-      <header class="hero" role="banner">
+      <header class="hero" id="hero" role="banner">
         <div class="hero__container">
           <div class="hero__content">
             <p class="hero__eyebrow">Ball Crusher Daily Recap</p>
@@ -38,6 +38,20 @@
           </figure>
         </div>
       </header>
+
+      <nav class="quick-nav" aria-label="Phone navigation">
+        <div class="quick-nav__container">
+          <button type="button" class="quick-nav__button" data-scroll-target="hero" aria-pressed="true">
+            Overview
+          </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="open-stats">
+            Open stats
+          </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="player-stats">
+            Player stats
+          </button>
+        </div>
+      </nav>
 
       <main class="main" id="content">
         <section id="open-stats" class="panel" aria-labelledby="open-stats-title">


### PR DESCRIPTION
## Summary
- capture and apply viewport metrics immediately on load, only re-computing when dimensions truly change to eliminate layout jumps
- broaden scaling calculations so typography, spacing, and layout widths stay within each device’s bounds while remaining centered
- prevent horizontal overscroll for a locked vertical scroll experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc5270e564832f80a0606a99575e7e