### PR TITLE
Improve player results list visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -472,8 +472,19 @@ a:focus {
 }
 
 .player-results {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: calc(1rem * var(--spacing-scale));
+}
+
+.player-results-summary {
+  margin: 0;
+  font-size: clamp(
+      calc(0.86rem * var(--font-scale)),
+      calc((0.82rem + 0.25vw) * var(--font-scale)),
+      calc(0.95rem * var(--font-scale))
+    );
+  color: var(--text-muted);
 }
 
 .player-result-card {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -465,6 +465,18 @@ function renderPlayerResults(entry) {
 
   playerResultsContainer.innerHTML = '';
 
+  if (!sortedRecords.length) {
+    playerResultsContainer.innerHTML = '<p class="no-results">No stats available.</p>';
+    return;
+  }
+
+  const summary = document.createElement('p');
+  summary.className = 'player-results-summary';
+  const count = sortedRecords.length;
+  const dayLabel = count === 1 ? 'day' : 'days';
+  summary.textContent = `Showing ${count} ${dayLabel} for ${entry.name}.`;
+  playerResultsContainer.append(summary);
+
   sortedRecords.forEach((record) => {
     const card = document.createElement('article');
     card.className = 'player-result-card';
@@ -497,10 +509,6 @@ function renderPlayerResults(entry) {
     card.append(meta, rank);
     playerResultsContainer.append(card);
   });
-
-  if (!sortedRecords.length) {
-    playerResultsContainer.innerHTML = '<p class="no-results">No stats available.</p>';
-  }
 }
 
 function startCanvasAnimation() {


### PR DESCRIPTION
## Summary
- ensure the player results list uses a column flex layout so all rendered days stay visible
- add a summary line that reports how many days were found for the selected player

## Testing
- Manual Playwright verification of the player search displaying all days for a sample athlete

------
https://chatgpt.com/codex/tasks/task_e_68cf1214f8ac832fa88013ae693dfbfd