### PR TITLE
Add request box workflow with Firebase and AdSense

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -119,6 +119,191 @@ a:focus {
   color: var(--text-secondary);
 }
 
+.request-box {
+  margin-top: calc(1.8rem * var(--spacing-scale));
+  padding: calc(1.4rem * var(--spacing-scale));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.88), rgba(14, 116, 144, 0.18));
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: calc(1.2rem * var(--spacing-scale));
+}
+
+.request-box__header {
+  display: grid;
+  gap: calc(0.4rem * var(--spacing-scale));
+}
+
+.request-box__title {
+  margin: 0;
+  font-size: clamp(calc(1.3rem * var(--font-scale)), calc(4vw * var(--font-scale)), calc(1.6rem * var(--font-scale)));
+}
+
+.request-box__description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: calc(0.98rem * var(--font-scale));
+  line-height: 1.6;
+}
+
+.request-box__form {
+  display: grid;
+  gap: calc(0.9rem * var(--spacing-scale));
+}
+
+.request-box__field {
+  display: grid;
+  gap: calc(0.35rem * var(--spacing-scale));
+  font-size: calc(0.88rem * var(--font-scale));
+  color: var(--text-muted);
+}
+
+.request-box__field input {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text-primary);
+  padding: calc(0.8rem * var(--spacing-scale)) calc(1rem * var(--spacing-scale));
+  font-size: calc(1rem * var(--font-scale));
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.request-box__field input:focus {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.25);
+}
+
+.request-box__button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: calc(0.85rem * var(--spacing-scale)) calc(1.4rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: none;
+  background: linear-gradient(135deg, #0ea5e9, #38bdf8);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: calc(1rem * var(--font-scale));
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease, box-shadow 0.2s ease;
+}
+
+.request-box__button:hover,
+.request-box__button:focus {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  box-shadow: 0 10px 30px rgba(14, 165, 233, 0.4);
+}
+
+.request-box__button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.request-box__status {
+  display: grid;
+  gap: calc(0.4rem * var(--spacing-scale));
+  font-size: calc(0.95rem * var(--font-scale));
+}
+
+.request-box__count {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.request-box__count-value {
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.request-box__message {
+  margin: 0;
+  padding: calc(0.65rem * var(--spacing-scale));
+  border-radius: var(--radius-sm);
+  font-size: calc(0.9rem * var(--font-scale));
+}
+
+.request-box__message--success {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
+.request-box__message--error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  color: #f87171;
+}
+
+.request-box__ad {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.55);
+  padding: calc(0.6rem * var(--spacing-scale));
+  min-height: 120px;
+  display: none;
+}
+
+.request-box__ad[hidden] {
+  display: none !important;
+}
+
+.request-box__ad:not([hidden]) {
+  display: block;
+}
+
+@media (min-width: 640px) {
+  .request-box {
+    padding: calc(1.8rem * var(--spacing-scale));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .request-box__header {
+    grid-column: 1 / -1;
+  }
+
+  .request-box__form {
+    grid-column: 1 / 3;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: calc(0.8rem * var(--spacing-scale));
+  }
+
+  .request-box__field {
+    grid-column: 1 / -1;
+  }
+
+  .request-box__button {
+    align-self: end;
+    height: 100%;
+  }
+
+  .request-box__status {
+    grid-column: 3 / -1;
+  }
+
+  .request-box__ad {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 420px) {
+  .request-box {
+    padding: calc(1.2rem * var(--spacing-scale));
+  }
+
+  .request-box__button {
+    width: 100%;
+  }
+}
+
 .hero__visual {
   margin: 0;
   padding: calc(1.2rem * var(--spacing-scale));

--- a/firebase-database.rules.json
+++ b/firebase-database.rules.json
@@ -1,0 +1,20 @@
+{
+  "rules": {
+    "requestBoxes": {
+      "$uid": {
+        ".read": "auth != null && auth.uid === $uid",
+        ".write": "auth != null && auth.uid === $uid",
+        ".validate": "newData.hasChildren(['count', 'name', 'updatedAt']) && newData.child('count').isNumber() && newData.child('count').val() >= 0 && newData.child('name').isString()"
+      }
+    },
+    "requestQueue": {
+      "$entryId": {
+        ".read": "auth != null",
+        ".write": "auth != null && newData.child('uid').val() === auth.uid",
+        ".validate": "newData.hasChildren(['name', 'uid', 'createdAt']) && newData.child('name').isString() && newData.child('uid').isString()"
+      }
+    },
+    ".read": false,
+    ".write": false
+  }
+}

--- a/index.html
+++ b/index.html
@@ -26,6 +26,47 @@
             <p class="hero__description">
               Here you can check your daily stats. This is just a pre-release version, so please be patient if you encounter any bugs — we’re working on fixing them soon!
             </p>
+            <section class="request-box" aria-labelledby="request-box-title">
+              <div class="request-box__header">
+                <h2 id="request-box-title" class="request-box__title">Request your box</h2>
+                <p class="request-box__description">
+                  Add your name to the daily queue, track how many boxes you have earned, and unlock a supporting ad with every request.
+                </p>
+              </div>
+              <form id="request-box-form" class="request-box__form" autocomplete="off" novalidate>
+                <label class="request-box__field" for="request-box-name">
+                  Your display name
+                  <input
+                    id="request-box-name"
+                    name="request-box-name"
+                    type="text"
+                    inputmode="text"
+                    maxlength="80"
+                    placeholder="e.g. PlayerLegend"
+                    required
+                  />
+                </label>
+                <button id="request-box-button" class="request-box__button" type="submit">
+                  Request Box
+                </button>
+              </form>
+              <div class="request-box__status" aria-live="polite">
+                <p class="request-box__count">
+                  You currently own
+                  <span id="request-box-count-value" class="request-box__count-value">0</span>
+                  boxes.
+                </p>
+                <p id="request-box-success" class="request-box__message request-box__message--success" hidden></p>
+                <p id="request-box-error" class="request-box__message request-box__message--error" hidden></p>
+              </div>
+              <div
+                id="request-box-ad"
+                class="request-box__ad"
+                data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+                data-ad-slot="0000000000"
+                hidden
+              ></div>
+            </section>
           </div>
           <figure class="hero__visual">
             <canvas
@@ -109,6 +150,22 @@
       </footer>
     </div>
 
+    <!--
+      Replace the placeholder values below with your real Firebase project configuration.
+      The application detects if the placeholders are still present and keeps the request
+      workflow disabled until valid credentials are supplied.
+    -->
+    <script id="firebase-config" type="application/json">
+      {
+        "apiKey": "YOUR_FIREBASE_API_KEY",
+        "authDomain": "YOUR_FIREBASE_AUTH_DOMAIN",
+        "databaseURL": "YOUR_FIREBASE_DATABASE_URL",
+        "projectId": "YOUR_FIREBASE_PROJECT_ID",
+        "storageBucket": "YOUR_FIREBASE_STORAGE_BUCKET",
+        "messagingSenderId": "YOUR_FIREBASE_SENDER_ID",
+        "appId": "YOUR_FIREBASE_APP_ID"
+      }
+    </script>
     <script src="assets/js/app.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a request box form with live status, ad placeholder, and Firebase config stub to the hero section
- style the new request box UI with responsive layout tweaks and themed accents for mobile and desktop
- integrate Firebase auth/database plus AdSense loading, realtime counter updates, and robust error handling in app.js
- document secure Firebase Realtime Database rules for request tracking

## Testing
- not run (static site without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d2cd617ed4832fa7044f4e753a564c