### PR TITLE
Add Firebase-backed request box workflow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -236,6 +236,162 @@ a:focus {
   backdrop-filter: blur(calc(18px * var(--elevation-scale)));
 }
 
+/*
+ * Dedicated styling for the request box panel so that the new workflow
+ * blends in with the existing design language while remaining easy to use
+ * on smaller displays. CSS variables keep the styling consistent with the
+ * theme and react gracefully to the dynamic viewport metrics applied via JS.
+ */
+.request-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.request-panel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 15%, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(circle at 80% -10%, rgba(14, 165, 233, 0.08), transparent 60%);
+  opacity: 0.9;
+}
+
+.request-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.request-form {
+  display: grid;
+  gap: calc(1.1rem * var(--spacing-scale));
+}
+
+.request-form__actions {
+  display: flex;
+  align-items: stretch;
+}
+
+.request-form__field label {
+  display: grid;
+  gap: calc(0.35rem * var(--spacing-scale));
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.request-form__field input {
+  width: 100%;
+  padding: calc(0.8rem * var(--spacing-scale)) calc(1rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text-primary);
+  font-size: calc(1rem * var(--font-scale));
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.request-form__field input:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.15);
+}
+
+.request-form__button {
+  appearance: none;
+  width: 100%;
+  padding: calc(0.85rem * var(--spacing-scale)) calc(1.4rem * var(--spacing-scale));
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.3), rgba(6, 182, 212, 0.45));
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: calc(1rem * var(--font-scale));
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+  box-shadow: 0 calc(18px * var(--elevation-scale)) calc(30px * var(--elevation-scale)) rgba(2, 6, 23, 0.45);
+}
+
+.request-form__button:hover,
+.request-form__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 calc(22px * var(--elevation-scale)) calc(36px * var(--elevation-scale)) rgba(2, 6, 23, 0.5);
+}
+
+.request-form__button:disabled {
+  cursor: wait;
+  opacity: 0.66;
+}
+
+.request-status {
+  display: grid;
+  gap: calc(0.6rem * var(--spacing-scale));
+  font-size: calc(0.95rem * var(--font-scale));
+  color: var(--text-secondary);
+}
+
+.request-counter strong {
+  color: var(--accent-strong);
+}
+
+.request-feedback {
+  margin: 0;
+  font-weight: 600;
+  min-height: calc(1.25rem * var(--font-scale));
+}
+
+.request-feedback.is-error {
+  color: #f87171;
+}
+
+.request-feedback.is-success {
+  color: #4ade80;
+}
+
+.adsense-container {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(56, 189, 248, 0.35);
+  background: rgba(8, 15, 35, 0.6);
+  padding: calc(1rem * var(--spacing-scale));
+  min-height: calc(5rem * var(--spacing-scale));
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: calc(0.85rem * var(--font-scale));
+  gap: calc(0.75rem * var(--spacing-scale));
+}
+
+.adsense-container::before {
+  content: 'Advertisement';
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.adsense-container .adsbygoogle {
+  width: 100%;
+}
+
+.adsense-placeholder {
+  margin: 0;
+  color: rgba(241, 245, 249, 0.72);
+  font-size: calc(0.78rem * var(--font-scale));
+}
+
+@media (min-width: 640px) {
+  .request-form {
+    grid-template-columns: 1fr auto;
+    align-items: end;
+  }
+
+  .request-form__actions {
+    min-width: calc(11rem * var(--spacing-scale));
+  }
+}
+
 .panel__header {
   display: grid;
   gap: calc(0.55rem * var(--spacing-scale));

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,15 @@
+import firebaseConfig from './firebase-config.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+import {
+  getDatabase,
+  ref as databaseRef,
+  push,
+  runTransaction,
+  serverTimestamp,
+  onValue,
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js';
+import { getAuth, signInAnonymously, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
 const DATA_URL = 'data/day_stats.json';
 
 const root = document.documentElement;
@@ -12,6 +24,17 @@ const quickNav = document.querySelector('.quick-nav');
 const quickNavButtons = quickNav
   ? Array.from(quickNav.querySelectorAll('.quick-nav__button'))
   : [];
+const requestForm = document.getElementById('request-box-form');
+const requestNameInput = document.getElementById('request-box-name');
+const requestButton = document.getElementById('request-box-button');
+const requestFeedback = document.getElementById('request-feedback');
+const requestBoxCountOutput = document.getElementById('request-box-count');
+const adsenseContainer = document.getElementById('adsense-container');
+
+// Amount of time (in milliseconds) we wait before refreshing the page after a
+// successful request. This gives the ad script enough time to render and keeps
+// the UX predictable on both desktop and mobile devices.
+const REQUEST_RELOAD_DELAY = 1800;
 
 const lastAppliedMetrics = {
   width: 0,
@@ -27,8 +50,459 @@ let canvasResizeHandler = null;
 let quickNavObserver = null;
 let metricsFrameId = null;
 
+// ---------------------------------------------------------------------------
+// Firebase state handling
+// ---------------------------------------------------------------------------
+let firebaseAppInstance = null;
+let firebaseDatabase = null;
+let firebaseAuth = null;
+let firebaseInitPromise = null;
+let authenticatedUser = null;
+let isFirebaseActive = false;
+let activeBoxCountUnsubscribe = null;
+let activeBoxCountKey = '';
+let hasInjectedAdSense = false;
+const requestButtonDefaultLabel = requestButton ? requestButton.textContent.trim() : '';
+
+let authReadyPromise = null;
+let authObserverUnsubscribe = null;
+let hasResolvedInitialAuth = false;
+// We persist the most recent player key and counter value so that UI updates
+// remain instant even before Firebase pushes the latest transaction result.
+let lastSanitizedNameKey = '';
+let lastKnownBoxCount = 0;
+
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Verifies that the Firebase configuration object contains real credentials
+ * instead of the placeholder strings checked into the repository.
+ */
+function isFirebaseConfigured() {
+  if (!firebaseConfig || typeof firebaseConfig !== 'object') {
+    return false;
+  }
+  const requiredKeys = ['apiKey', 'authDomain', 'databaseURL', 'projectId', 'appId'];
+  return requiredKeys.every((key) => {
+    const value = firebaseConfig[key];
+    if (typeof value !== 'string' || !value.trim()) {
+      return false;
+    }
+    return !value.includes('YOUR_');
+  });
+}
+
+/**
+ * Creates (or reuses) a promise that resolves once Firebase Auth has produced
+ * an authenticated user. Anonymous sign-in is enough for our use case and the
+ * promise ensures we wait for the credential before writing any data.
+ */
+function createAuthReadyPromise() {
+  if (!firebaseAuth) {
+    return Promise.reject(new Error('Firebase authentication service is not available.'));
+  }
+  if (authReadyPromise) {
+    return authReadyPromise;
+  }
+  if (authObserverUnsubscribe) {
+    authObserverUnsubscribe();
+    authObserverUnsubscribe = null;
+  }
+  hasResolvedInitialAuth = false;
+  authReadyPromise = new Promise((resolve, reject) => {
+    authObserverUnsubscribe = onAuthStateChanged(
+      firebaseAuth,
+      (user) => {
+        authenticatedUser = user;
+        if (user && !hasResolvedInitialAuth) {
+          hasResolvedInitialAuth = true;
+          resolve(user);
+        }
+      },
+      (error) => {
+        console.error('Firebase auth listener error:', error);
+        if (!hasResolvedInitialAuth) {
+          reject(error);
+        }
+      },
+    );
+  });
+  return authReadyPromise;
+}
+
+/**
+ * Lazily bootstraps the Firebase App, Database and Auth instances. The
+ * function guards against duplicate initialisation and surfaces meaningful
+ * errors when the configuration is missing or authentication fails.
+ */
+async function ensureFirebaseConnection() {
+  if (isFirebaseActive && firebaseAppInstance && firebaseDatabase && firebaseAuth) {
+    return true;
+  }
+  if (firebaseInitPromise) {
+    return firebaseInitPromise;
+  }
+  if (!isFirebaseConfigured()) {
+    throw new Error('Firebase configuration missing. Update assets/js/firebase-config.js first.');
+  }
+
+  firebaseInitPromise = (async () => {
+    try {
+      firebaseAppInstance = initializeApp(firebaseConfig);
+      firebaseDatabase = getDatabase(firebaseAppInstance);
+      firebaseAuth = getAuth(firebaseAppInstance);
+
+      const readyPromise = createAuthReadyPromise();
+
+      if (!firebaseAuth.currentUser) {
+        try {
+          await signInAnonymously(firebaseAuth);
+        } catch (error) {
+          if (error?.code === 'auth/operation-not-allowed') {
+            throw new Error('Enable anonymous authentication in Firebase to use the request button.');
+          }
+          throw error;
+        }
+      }
+
+      await readyPromise;
+      isFirebaseActive = true;
+      return true;
+    } catch (error) {
+      isFirebaseActive = false;
+      authReadyPromise = null;
+      if (authObserverUnsubscribe) {
+        authObserverUnsubscribe();
+        authObserverUnsubscribe = null;
+      }
+      throw error;
+    }
+  })();
+
+  firebaseInitPromise.finally(() => {
+    firebaseInitPromise = null;
+  });
+
+  return firebaseInitPromise;
+}
+
+/**
+ * Normalises a player name so that we can safely use it as a Firebase key.
+ * All non-alphanumeric characters become dashes and the final key is capped
+ * to a conservative length to keep database paths tidy.
+ */
+function sanitizePlayerKey(rawName) {
+  if (typeof rawName !== 'string') {
+    return '';
+  }
+  const normalized = rawName.trim().toLowerCase();
+  if (!normalized) {
+    return '';
+  }
+  const sanitized = normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return sanitized.slice(0, 80);
+}
+
+/**
+ * Synchronises the live counter UI with the latest box count value.
+ */
+function updateBoxCountDisplay(value) {
+  if (!requestBoxCountOutput) {
+    return;
+  }
+  const numeric = Number.isFinite(value)
+    ? value
+    : Number.isFinite(Number.parseInt(value, 10))
+      ? Number.parseInt(value, 10)
+      : 0;
+  const safeValue = Math.max(0, Math.round(numeric));
+  requestBoxCountOutput.textContent = String(safeValue);
+  lastKnownBoxCount = safeValue;
+}
+
+/**
+ * Displays contextual feedback below the form, colouring the text depending
+ * on whether we are showing an error, success message, or a neutral note.
+ */
+function showRequestFeedback(message, tone = 'info') {
+  if (!requestFeedback) {
+    return;
+  }
+  requestFeedback.textContent = message;
+  requestFeedback.className = 'request-feedback';
+  if (tone === 'error') {
+    requestFeedback.classList.add('is-error');
+  } else if (tone === 'success') {
+    requestFeedback.classList.add('is-success');
+  }
+}
+
+/**
+ * Toggles the submit button and input field between idle and loading states.
+ * Keeping the interaction responsive helps avoid duplicate submissions.
+ */
+function toggleRequestLoadingState(isLoading) {
+  if (requestButton) {
+    requestButton.disabled = isLoading;
+    requestButton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    requestButton.textContent = isLoading
+      ? 'Requesting…'
+      : requestButtonDefaultLabel || 'Request box';
+  }
+  if (requestNameInput) {
+    requestNameInput.readOnly = isLoading;
+  }
+}
+
+/**
+ * Removes the active Firebase listener that keeps the counter in sync.
+ */
+function stopWatchingBoxCount() {
+  if (typeof activeBoxCountUnsubscribe === 'function') {
+    activeBoxCountUnsubscribe();
+  }
+  activeBoxCountUnsubscribe = null;
+  activeBoxCountKey = '';
+}
+
+/**
+ * Subscribes to the realtime counter for the provided player key so that the
+ * UI reflects increments triggered by the current tab or other devices.
+ */
+function startWatchingBoxCount(playerKey) {
+  if (!playerKey || !isFirebaseActive || !firebaseDatabase) {
+    return;
+  }
+  if (activeBoxCountKey === playerKey) {
+    return;
+  }
+  stopWatchingBoxCount();
+  const counterRef = databaseRef(firebaseDatabase, `boxCounts/${playerKey}`);
+  activeBoxCountKey = playerKey;
+  activeBoxCountUnsubscribe = onValue(
+    counterRef,
+    (snapshot) => {
+      const value = snapshot.val();
+      const numeric = typeof value === 'number' ? value : Number.parseInt(value, 10);
+      updateBoxCountDisplay(Number.isFinite(numeric) && numeric > 0 ? numeric : 0);
+    },
+    (error) => {
+      console.error('Realtime box count listener failed:', error);
+      showRequestFeedback('Unable to update the box counter right now. Please retry shortly.', 'error');
+    },
+  );
+  lastSanitizedNameKey = playerKey;
+}
+
+/**
+ * Responds to name input changes and attaches/detaches realtime listeners
+ * depending on whether the user has entered a valid nickname.
+ */
+function handleRequestNameInput() {
+  if (!requestNameInput) {
+    return;
+  }
+  const rawName = requestNameInput.value.trim();
+  if (!rawName) {
+    stopWatchingBoxCount();
+    updateBoxCountDisplay(0);
+    showRequestFeedback('');
+    return;
+  }
+  if (!isFirebaseActive) {
+    return;
+  }
+  const playerKey = sanitizePlayerKey(rawName);
+  if (!playerKey) {
+    stopWatchingBoxCount();
+    updateBoxCountDisplay(0);
+    return;
+  }
+  lastSanitizedNameKey = playerKey;
+  startWatchingBoxCount(playerKey);
+}
+
+/**
+ * Handles the "Request box" submission, storing the request record and
+ * incrementing the aggregate counter inside the Firebase Realtime Database.
+ */
+async function handleRequestFormSubmit(event) {
+  event.preventDefault();
+  if (!requestNameInput) {
+    return;
+  }
+
+  const rawName = requestNameInput.value.trim();
+  if (!rawName) {
+    showRequestFeedback('Please enter your player name before requesting a box.', 'error');
+    requestNameInput.focus();
+    return;
+  }
+
+  const playerKey = sanitizePlayerKey(rawName);
+  if (!playerKey) {
+    showRequestFeedback('Use at least one letter or number in your player name.', 'error');
+    requestNameInput.focus();
+    return;
+  }
+
+  toggleRequestLoadingState(true);
+  showRequestFeedback('');
+
+  try {
+    await ensureFirebaseConnection();
+    lastSanitizedNameKey = playerKey;
+    startWatchingBoxCount(playerKey);
+
+    const requestsNode = databaseRef(firebaseDatabase, 'requests');
+    await push(requestsNode, {
+      name: rawName,
+      key: playerKey,
+      requestedAt: serverTimestamp(),
+      uid: authenticatedUser ? authenticatedUser.uid : null,
+    });
+
+    const counterRef = databaseRef(firebaseDatabase, `boxCounts/${playerKey}`);
+    const transactionResult = await runTransaction(counterRef, (currentValue) => {
+      const numeric =
+        typeof currentValue === 'number'
+          ? currentValue
+          : typeof currentValue === 'string'
+            ? Number.parseInt(currentValue, 10)
+            : 0;
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        return 1;
+      }
+      return numeric + 1;
+    });
+
+    const transactionValue = transactionResult?.snapshot?.val();
+    const numericCount =
+      typeof transactionValue === 'number'
+        ? transactionValue
+        : Number.parseInt(transactionValue, 10);
+    const fallbackCount = playerKey === lastSanitizedNameKey ? lastKnownBoxCount + 1 : 1;
+    const updatedCount = Number.isFinite(numericCount) ? numericCount : fallbackCount;
+
+    updateBoxCountDisplay(updatedCount);
+
+    const successMessage = `Request stored! You now have ${updatedCount} request box${
+      updatedCount === 1 ? '' : 'es'
+    }.`;
+    showRequestFeedback(successMessage, 'success');
+
+    showAdSenseContainer();
+
+    setTimeout(() => {
+      window.location.reload();
+    }, REQUEST_RELOAD_DELAY);
+  } catch (error) {
+    console.error('Request box submission failed:', error);
+    let message = 'Something went wrong while talking to the server. Please try again later.';
+    if (typeof error?.message === 'string' && error.message) {
+      message = error.message;
+    }
+    showRequestFeedback(message, 'error');
+    toggleRequestLoadingState(false);
+  }
+}
+
+/**
+ * Makes the AdSense container visible and injects the Google script on demand.
+ * The placeholder client and slot values must be replaced before production.
+ */
+function showAdSenseContainer() {
+  if (!adsenseContainer) {
+    return;
+  }
+  adsenseContainer.hidden = false;
+
+  let placeholderMessage = adsenseContainer.querySelector('.adsense-placeholder');
+
+  if (!hasInjectedAdSense) {
+    const adSlot = document.createElement('ins');
+    adSlot.className = 'adsbygoogle request-box-ad';
+    adSlot.style.display = 'block';
+    adSlot.setAttribute('data-ad-client', 'ca-pub-0000000000000000');
+    adSlot.setAttribute('data-ad-slot', '0000000000');
+    adSlot.setAttribute('data-ad-format', 'auto');
+    adSlot.setAttribute('data-full-width-responsive', 'true');
+    adSlot.setAttribute('aria-label', 'Google AdSense advertisement');
+    adsenseContainer.append(adSlot);
+
+    if (!placeholderMessage) {
+      placeholderMessage = document.createElement('p');
+      placeholderMessage.className = 'adsense-placeholder';
+      placeholderMessage.textContent =
+        'Replace the AdSense client and slot IDs to render your production advertisement.';
+      adsenseContainer.append(placeholderMessage);
+    }
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+    script.setAttribute('data-adsbygoogle-loaded', 'true');
+    script.addEventListener('load', () => {
+      try {
+        window.adsbygoogle = window.adsbygoogle || [];
+        window.adsbygoogle.push({});
+        if (placeholderMessage) {
+          placeholderMessage.remove();
+        }
+      } catch (adError) {
+        console.error('AdSense rendering failed:', adError);
+      }
+    });
+    script.addEventListener('error', () => {
+      console.error('Failed to load the Google AdSense script.');
+    });
+    document.head.append(script);
+    hasInjectedAdSense = true;
+  } else {
+    try {
+      window.adsbygoogle = window.adsbygoogle || [];
+      window.adsbygoogle.push({});
+    } catch (error) {
+      console.error('AdSense refresh failed:', error);
+    }
+  }
+}
+
+/**
+ * Wires up DOM event listeners for the request box workflow and initialises
+ * Firebase when a configuration is present.
+ */
+function setupRequestBoxModule() {
+  if (!requestForm || !requestNameInput || !requestButton || !requestBoxCountOutput) {
+    return;
+  }
+
+  requestForm.addEventListener('submit', handleRequestFormSubmit);
+  requestNameInput.addEventListener('input', handleRequestNameInput);
+  requestNameInput.addEventListener('change', handleRequestNameInput);
+
+  updateBoxCountDisplay(0);
+
+  if (!isFirebaseConfigured()) {
+    showRequestFeedback('Configure Firebase to enable the Request Box feature.', 'error');
+    requestButton.disabled = true;
+    return;
+  }
+
+  ensureFirebaseConnection()
+    .then(() => {
+      handleRequestNameInput();
+    })
+    .catch((error) => {
+      console.error('Failed to initialize Firebase for request boxes:', error);
+      showRequestFeedback(
+        'Unable to connect to Firebase. Please verify your credentials or try again later.',
+        'error',
+      );
+      requestButton.disabled = true;
+    });
 }
 
 function resolveBoxCount(player) {
@@ -703,6 +1177,8 @@ function buildInstagramLink(name) {
   const sanitized = name.replace(/[^a-z0-9._-]/gi, '');
   return `https://instagram.com/${sanitized}`;
 }
+
+setupRequestBoxModule();
 
 playerSearchInput.addEventListener('change', () => updatePlayerResults());
 playerSearchInput.addEventListener('input', () => {

--- a/assets/js/firebase-config.js
+++ b/assets/js/firebase-config.js
@@ -1,0 +1,16 @@
+// Firebase configuration placeholder.
+// -----------------------------------------------------------------------------
+// Replace the placeholder strings below with the credentials from your Firebase
+// project. These values are injected into the Firebase SDK when the page loads.
+// Never commit production secrets to public repositories.
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_PROJECT_ID.firebaseapp.com',
+  databaseURL: 'https://YOUR_PROJECT_ID-default-rtdb.firebaseio.com',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+export default firebaseConfig;

--- a/firebase.database.rules.json
+++ b/firebase.database.rules.json
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    ".read": true,
+    "requests": {
+      ".write": "auth != null",
+      "$requestId": {
+        ".validate": "newData.hasChildren(['name','key','requestedAt']) && newData.child('name').isString() && newData.child('name').val().length > 0 && newData.child('name').val().length <= 80 && newData.child('key').isString() && newData.child('key').val().length > 0 && newData.child('key').val().length <= 80 && newData.child('requestedAt').isNumber() && (!newData.hasChildren(['uid']) || newData.child('uid').isString())"
+      }
+    },
+    "boxCounts": {
+      ".write": "auth != null",
+      "$playerKey": {
+        ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 10000"
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -44,6 +44,9 @@
           <button type="button" class="quick-nav__button" data-scroll-target="hero" aria-pressed="true">
             Overview
           </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="request-box">
+            Request box
+          </button>
           <button type="button" class="quick-nav__button" data-scroll-target="open-stats">
             Open stats
           </button>
@@ -54,6 +57,48 @@
       </nav>
 
       <main class="main" id="content">
+        <section id="request-box" class="panel request-panel" aria-labelledby="request-panel-title">
+          <div class="panel__header">
+            <h2 id="request-panel-title" class="panel__title">Request Box</h2>
+            <span class="panel__subtitle"
+              >Submit your nickname, request an additional box, and keep track of your running total in real time.</span
+            >
+          </div>
+          <form id="request-box-form" class="request-form" autocomplete="on" novalidate>
+            <div class="request-form__field">
+              <label for="request-box-name">
+                Player name
+                <input
+                  type="text"
+                  id="request-box-name"
+                  name="request-box-name"
+                  inputmode="text"
+                  maxlength="80"
+                  placeholder="e.g. PlayerOne"
+                  autocomplete="name"
+                  required
+                />
+              </label>
+            </div>
+            <div class="request-form__actions">
+              <button type="submit" id="request-box-button" class="request-form__button">Request box</button>
+            </div>
+          </form>
+          <div class="request-status">
+            <p class="request-counter" aria-live="polite">
+              You currently have <strong id="request-box-count">0</strong> request boxes.
+            </p>
+            <p id="request-feedback" class="request-feedback" role="status" aria-live="assertive"></p>
+          </div>
+          <div
+            id="adsense-container"
+            class="adsense-container"
+            hidden
+            aria-live="polite"
+            aria-label="Sponsored message"
+          ></div>
+        </section>
+
         <section id="open-stats" class="panel" aria-labelledby="open-stats-title">
           <div class="panel__header">
             <h2 id="open-stats-title" class="panel__title">Open Stats</h2>


### PR DESCRIPTION
## Summary
- add a Request Box panel with form, live counter, and delayed reload to keep AdSense visible
- integrate Firebase Realtime Database and anonymous auth to store requests and track per-player box counts
- provide Firebase config placeholder, AdSense injection, and database security rules alongside responsive styling updates

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d2cd617ed4832fa7044f4e753a564c