### PR TITLE
Add extra box flow with Firebase and ad integrations

### DIFF
--- a/EXTRA_BOX_SETUP.md
+++ b/EXTRA_BOX_SETUP.md
@@ -1,0 +1,170 @@
+# Extra Box Feature Setup Guide
+
+This document explains the overall concept of the new **Extra Box** panel and
+guides you through the Firebase + Google Ads configuration that you need to
+complete before going live.
+
+## Concept overview
+
+1. Visitors can scroll to the **Extra Box** panel at the bottom of the page.
+2. They enter their player name (with suggestions taken from the daily stats
+   JSON) and press **“Get an extra box”**.
+3. The site reads the player's current totals from a Firebase Firestore
+   collection named `extraBoxes`.
+4. The interface displays both the cumulative number of boxes and the number of
+   boxes earned for the latest competition day (determined from
+   `data/day_stats.json`).
+5. The **Request box** button becomes available. When pressed, the site asks the
+   visitor to watch a rewarded Google Ad.
+6. After the ad finishes, Firestore increments the player's counters and the
+   page reloads so that fresh banner ads are fetched automatically.
+
+## Firebase configuration
+
+### 1. Create a Firestore database
+
+* Create a Firebase project (or reuse an existing project).
+* Enable **Firestore** in production mode.
+* Under **Firestore Database → Data**, create a collection named
+  `extraBoxes` (you can change the collection name by editing
+  `window.EXTRA_BOX_CONFIG.firestoreCollection`).
+
+### 2. Document structure
+
+Each document inside the collection should use the player's slugified name as
+its ID (the app automatically lowercases the name and removes special
+characters). The document schema looks like this:
+
+```json
+{
+  "name": "vermixo",
+  "totalBoxes": 12,
+  "daily": {
+    "13": 1,
+    "12": 2
+  },
+  "createdAt": <server timestamp>,
+  "updatedAt": <server timestamp>
+}
+```
+
+* `totalBoxes` — running total for that player.
+* `daily` — object keyed by day number. Each value tracks how many extra boxes
+  were granted on that day.
+* `createdAt`/`updatedAt` — maintained automatically by the code via
+  `serverTimestamp()`.
+
+The application will create or update documents for you; you do **not** need to
+pre-populate data manually.
+
+### 3. Firestore security rules
+
+Allow only authenticated updates in production. For local testing you can use a
+relaxed rule, but remember to lock it down before launch. A minimum viable rule
+set for authenticated users could look like:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /extraBoxes/{playerId} {
+      allow read: if true; // Everyone may read counts.
+      allow write: if request.auth != null; // Require authentication for writes.
+    }
+  }
+}
+```
+
+Adjust the `allow write` clause to fit your app's authentication story.
+
+### 4. Add the Firebase web SDK keys
+
+In `index.html` you will find the configuration blueprint:
+
+```html
+<script>
+  window.EXTRA_BOX_CONFIG = {
+    firebaseConfig: {
+      apiKey: 'YOUR_FIREBASE_API_KEY',
+      authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
+      projectId: 'YOUR_FIREBASE_PROJECT_ID',
+      storageBucket: 'YOUR_FIREBASE_STORAGE_BUCKET',
+      messagingSenderId: 'YOUR_FIREBASE_MESSAGING_SENDER_ID',
+      appId: 'YOUR_FIREBASE_APP_ID',
+    },
+    // …
+  };
+</script>
+```
+
+Replace each placeholder with your real Firebase project values. The JavaScript
+verifies that the placeholders were updated before enabling the feature.
+
+## Google Ads integration
+
+### 1. Banner ads
+
+* Create two banner units (for example in Google AdSense or Google Ad Manager).
+* Insert their unit IDs into `window.EXTRA_BOX_CONFIG.googleAds.bannerUnitIds`:
+
+```js
+bannerUnitIds: [
+  'ca-pub-1234567890123456/EXTRA_BOX_TOP',
+  'ca-pub-1234567890123456/EXTRA_BOX_BOTTOM'
+],
+```
+
+* Replace the placeholder `<div class="extra-box__banner-placeholder">…</div>`
+  inside each banner container with the `<ins class="adsbygoogle">` snippet
+  supplied by Google. The layout wrapper already exists, so you only need to
+  drop in the snippet and ensure `adsbygoogle.push({});` runs.
+* Provide your publisher ID via `googleAds.publisherId`. The script loads the
+  official Google Ads library automatically when a publisher ID is present.
+
+### 2. Rewarded ad
+
+* Create a **rewarded** ad unit and set its ID in
+  `googleAds.rewardedUnitId`.
+* Implement a custom loader by defining `window.extraBoxShowRewardedAd`. The
+  helper receives the ad unit ID and a container element where you can render
+  Google's rewarded ad UI. Return `false` if the ad was closed before
+  completion, otherwise return `true` (or an object with `{ completed: true }`).
+
+Example skeleton:
+
+```html
+<script>
+  window.extraBoxShowRewardedAd = async ({ unitId, container }) => {
+    // TODO: Initialize Google Publisher Tag or another rewarded ads SDK here.
+    // Mount the ad inside `container` and wait for it to finish.
+    await loadRewardedAd(unitId, container);
+    return { completed: true };
+  };
+</script>
+```
+
+Until you provide this function, the site simulates a rewarded ad with a short
+3.5 second delay so you can test the Firebase flow without third-party
+dependencies.
+
+### 3. Auto-reloading after rewards
+
+After a rewarded ad completes and Firestore updates successfully, the page
+reloads. This ensures both banner slots fetch a fresh ad, as requested.
+
+## Troubleshooting checklist
+
+* **No Firebase data appears** — double-check that all Firebase keys are filled
+  in and that the Firestore rules allow reads.
+* **Writes fail** — inspect the browser console for detailed errors. Most
+  issues stem from missing authentication in the security rules or from not
+  enabling Firestore in the Firebase console.
+* **Ads do not show** — confirm that the `publisherId` and ad unit IDs do not
+  contain placeholder fragments such as `XXXXXXXXXXXXXXXX`. Replace the
+  placeholder `<div>` with the official `<ins>` block from Google.
+* **Rewarded ad does nothing** — make sure you implemented
+  `window.extraBoxShowRewardedAd`. Without it, the simulation runs but no real
+  monetisation occurs.
+
+With these steps completed the Extra Box panel will be fully operational and
+ready for production traffic.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -559,6 +559,197 @@ a:focus {
   border: 1px solid rgba(148, 163, 184, 0.24);
 }
 
+/*
+  Extra box panel styling
+  -----------------------
+  Grouping the "Extra Box" rules keeps the feature modular. Each selector
+  is named with the BEM pattern so future adjustments are predictable.
+*/
+.panel--extra {
+  position: relative;
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.16), rgba(15, 23, 42, 0.78));
+  overflow: hidden;
+}
+
+.panel--extra::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(56, 189, 248, 0.28), transparent 62%);
+  pointer-events: none;
+  opacity: 0.65;
+}
+
+.extra-box {
+  position: relative;
+  display: grid;
+  gap: calc(1.2rem * var(--spacing-scale));
+}
+
+.extra-box__banners {
+  display: grid;
+  gap: calc(0.85rem * var(--spacing-scale));
+}
+
+.extra-box__banner {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  padding: calc(0.85rem * var(--spacing-scale));
+  background: rgba(15, 23, 42, 0.68);
+  position: relative;
+  overflow: hidden;
+}
+
+.extra-box__banner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.18);
+  pointer-events: none;
+}
+
+.extra-box__banner-placeholder {
+  font-size: calc(0.82rem * var(--font-scale));
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  text-align: center;
+}
+
+.extra-box__form {
+  display: grid;
+  gap: calc(0.85rem * var(--spacing-scale));
+}
+
+.extra-box__label {
+  display: grid;
+  gap: calc(0.45rem * var(--spacing-scale));
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.extra-box__label input {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(2, 6, 23, 0.68);
+  color: var(--text-primary);
+  font: inherit;
+  padding: calc(0.85rem * var(--spacing-scale));
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.extra-box__label input:focus,
+.extra-box__label input:hover {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.28);
+}
+
+.extra-box__submit,
+.extra-box__request {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: calc(0.85rem * var(--spacing-scale)) calc(1.2rem * var(--spacing-scale));
+  font-size: clamp(calc(0.92rem * var(--font-scale)),
+      calc((0.86rem + 0.22vw) * var(--font-scale)), calc(1.05rem * var(--font-scale)));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, box-shadow 160ms ease;
+  justify-self: flex-start;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.82), rgba(56, 189, 248, 0.62));
+  color: #03111e;
+  box-shadow: 0 calc(12px * var(--elevation-scale)) calc(22px * var(--elevation-scale)) rgba(8, 15, 35, 0.42);
+}
+
+.extra-box__submit:hover,
+.extra-box__submit:focus-visible,
+.extra-box__request:hover,
+.extra-box__request:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 calc(16px * var(--elevation-scale)) calc(34px * var(--elevation-scale)) rgba(8, 15, 35, 0.6);
+}
+
+.extra-box__request[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.extra-box__status {
+  min-height: 1.2rem;
+  font-size: calc(0.88rem * var(--font-scale));
+  color: var(--text-muted);
+}
+
+.extra-box__status[data-tone='error'] {
+  color: #fda4af;
+}
+
+.extra-box__status[data-tone='success'] {
+  color: #a7f3d0;
+}
+
+.extra-box__summary {
+  display: grid;
+  gap: calc(0.4rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+}
+
+.extra-box__summary-line {
+  margin: 0;
+  font-size: calc(0.92rem * var(--font-scale));
+  color: var(--text-secondary);
+}
+
+.extra-box__rewarded {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(56, 189, 248, 0.42);
+  padding: calc(1rem * var(--spacing-scale));
+  background: rgba(8, 15, 35, 0.72);
+  display: grid;
+  place-items: center;
+  gap: calc(0.6rem * var(--spacing-scale));
+}
+
+.extra-box__rewarded-inner {
+  display: grid;
+  gap: calc(0.35rem * var(--spacing-scale));
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: calc(0.9rem * var(--font-scale));
+}
+
+.extra-box__rewarded-copy {
+  margin: 0;
+}
+
+@media (min-width: 680px) {
+  .extra-box__banners {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .extra-box__banner {
+    min-height: 140px;
+  }
+
+  .extra-box__form {
+    grid-template-columns: 1fr auto;
+    align-items: end;
+  }
+}
+
 @media (min-width: 560px) {
   :root {
     --layout-max-width: 540px;

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
           <button type="button" class="quick-nav__button" data-scroll-target="player-stats">
             Player stats
           </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="extra-box">
+            Extra box
+          </button>
         </div>
       </nav>
 
@@ -102,6 +105,74 @@
             </div>
           </div>
         </section>
+
+        <section id="extra-box" class="panel panel--extra" aria-labelledby="extra-box-title">
+          <div class="panel__header">
+            <h2 id="extra-box-title" class="panel__title">Extra Box</h2>
+            <span class="panel__subtitle">Enter your name to get an extra box</span>
+          </div>
+
+          <div class="extra-box" aria-live="polite">
+            <div class="extra-box__banners" aria-label="Sponsored banners">
+              <div class="extra-box__banner" id="extra-box-banner-top" data-ad-slot-index="0">
+                <!--
+                  Google Ads banner placeholder (top).
+                  Replace the <div> below with the official Google Ads code snippet once you have created a banner unit.
+                  Keep the surrounding container so the layout stays consistent before the ad loads.
+                -->
+                <div class="extra-box__banner-placeholder">Ad banner placeholder (top)</div>
+              </div>
+              <div class="extra-box__banner" id="extra-box-banner-bottom" data-ad-slot-index="1">
+                <!--
+                  Google Ads banner placeholder (bottom).
+                  You can drop the AdSense/Google Ad Manager <ins> tag inside this container; the script will attach automatically.
+                  Until you do, this placeholder keeps the layout stable and accessible.
+                -->
+                <div class="extra-box__banner-placeholder">Ad banner placeholder (bottom)</div>
+              </div>
+            </div>
+
+            <form id="extra-box-form" class="extra-box__form" autocomplete="off" novalidate>
+              <label for="extra-box-name" class="extra-box__label">
+                Player name
+                <input
+                  type="search"
+                  id="extra-box-name"
+                  name="extra-box-name"
+                  placeholder="e.g. player1"
+                  list="player-suggestions"
+                  autocomplete="off"
+                  required
+                />
+              </label>
+              <button type="submit" class="extra-box__submit">
+                Get an extra box
+              </button>
+            </form>
+
+            <div class="extra-box__status" id="extra-box-status" role="status"></div>
+
+            <div class="extra-box__summary" id="extra-box-summary" hidden>
+              <p class="extra-box__summary-line" id="extra-box-total"></p>
+              <p class="extra-box__summary-line" id="extra-box-daily"></p>
+            </div>
+
+            <button type="button" class="extra-box__request" id="extra-box-request" disabled>
+              Request box
+            </button>
+
+            <div class="extra-box__rewarded" id="extra-box-rewarded" hidden>
+              <!--
+                Rewarded Ad container placeholder.
+                When you wire a Google rewarded ad, render it inside the element below.
+                The JavaScript toggles this wrapper to display a loading skeleton while the ad is being prepared.
+              -->
+              <div class="extra-box__rewarded-inner" id="extra-box-rewarded-inner">
+                <p class="extra-box__rewarded-copy">Loading rewarded ad…</p>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
 
       <footer class="page__footer">
@@ -109,6 +180,32 @@
       </footer>
     </div>
 
+    <!--
+      Extra box configuration blueprint.
+      Replace the placeholder values with your live Firebase + Google Ads settings before deploying.
+      Keeping the configuration in a dedicated object prevents accidentally committing secrets to the repository.
+    -->
+    <script>
+      window.EXTRA_BOX_CONFIG = {
+        firebaseConfig: {
+          apiKey: 'YOUR_FIREBASE_API_KEY',
+          authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
+          projectId: 'YOUR_FIREBASE_PROJECT_ID',
+          storageBucket: 'YOUR_FIREBASE_STORAGE_BUCKET',
+          messagingSenderId: 'YOUR_FIREBASE_MESSAGING_SENDER_ID',
+          appId: 'YOUR_FIREBASE_APP_ID',
+        },
+        googleAds: {
+          publisherId: 'ca-pub-XXXXXXXXXXXXXXXX',
+          rewardedUnitId: 'ca-pub-XXXXXXXXXXXXXXXX/REWARDED_SLOT_ID',
+          bannerUnitIds: [
+            'ca-pub-XXXXXXXXXXXXXXXX/BANNER_TOP_SLOT_ID',
+            'ca-pub-XXXXXXXXXXXXXXXX/BANNER_BOTTOM_SLOT_ID',
+          ],
+        },
+        firestoreCollection: 'extraBoxes',
+      };
+    </script>
     <script src="assets/js/app.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an Extra Box navigation entry, section layout, and configuration blueprint for Firebase + Google Ads
- style the new panel, ad placeholders, and rewarded ad wrapper to match the existing UI
- implement Firebase-powered lookup/increment logic, rewarded ad hooks, and guidance docs for wiring the feature

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2d9c20534832fa3da55e79a0d2df3