### PR TITLE
Add extra box rewarded flow with Firebase and ad integration

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -542,6 +542,213 @@ a:focus {
   font-style: italic;
 }
 
+/*
+  Extra box feature styles
+  ---------------------------------------------------------------------------
+  The block below styles the rewarded extra box flow, its banners, form and
+  status messages. The layout intentionally mirrors the other cards so the
+  section blends with the rest of the page.
+*/
+.extra-box-card {
+  display: grid;
+  gap: calc(1.6rem * var(--spacing-scale));
+  margin-top: calc(1.8rem * var(--spacing-scale));
+  padding: calc(1.5rem * var(--spacing-scale)) calc(1.35rem * var(--spacing-scale));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.72);
+  box-shadow: var(--shadow-soft);
+}
+
+.extra-box-card__ads {
+  display: grid;
+  gap: calc(1.05rem * var(--spacing-scale));
+}
+
+.ads-banner {
+  padding: calc(0.75rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  position: relative;
+  overflow: hidden;
+}
+
+.ads-banner--secondary {
+  min-height: 90px;
+}
+
+.ads-banner .adsbygoogle {
+  display: block !important;
+  width: 100% !important;
+  min-height: 60px;
+}
+
+.extra-box-form {
+  display: grid;
+  gap: calc(1.2rem * var(--spacing-scale));
+}
+
+.extra-box-form__field {
+  display: grid;
+  gap: calc(0.55rem * var(--spacing-scale));
+}
+
+.extra-box-form__field label {
+  display: grid;
+  gap: calc(0.45rem * var(--spacing-scale));
+  font-size: clamp(calc(0.78rem * var(--font-scale)),
+      calc((0.74rem + 0.25vw) * var(--font-scale)), calc(0.9rem * var(--font-scale)));
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.extra-box-form__field input {
+  width: 100%;
+  padding: clamp(calc(0.72rem * var(--spacing-scale)),
+      calc((0.68rem + 0.4vw) * var(--spacing-scale)),
+      calc(0.95rem * var(--spacing-scale)))
+    clamp(calc(0.9rem * var(--spacing-scale)), calc((0.82rem + 0.7vw) * var(--spacing-scale)),
+      calc(1.25rem * var(--spacing-scale)));
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.82);
+  color: var(--text-primary);
+  font-size: clamp(calc(0.98rem * var(--font-scale)),
+      calc((0.94rem + 0.35vw) * var(--font-scale)), calc(1.1rem * var(--font-scale)));
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.extra-box-form__field input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+}
+
+.extra-box-form__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(0.6rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale)) calc(1rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  background: rgba(13, 148, 136, 0.16);
+  border: 1px solid rgba(45, 212, 191, 0.22);
+  color: #5eead4;
+  font-size: clamp(calc(0.86rem * var(--font-scale)),
+      calc((0.82rem + 0.25vw) * var(--font-scale)), calc(0.98rem * var(--font-scale)));
+}
+
+.extra-box-form__summary-value {
+  font-size: clamp(calc(1.25rem * var(--font-scale)),
+      calc((1.15rem + 0.45vw) * var(--font-scale)), calc(1.5rem * var(--font-scale)));
+  font-weight: 700;
+  color: #bbf7d0;
+}
+
+.extra-box__feedback {
+  margin: 0;
+  padding: calc(0.75rem * var(--spacing-scale)) calc(0.95rem * var(--spacing-scale));
+  border-radius: var(--radius-sm);
+  font-size: clamp(calc(0.82rem * var(--font-scale)),
+      calc((0.78rem + 0.3vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: var(--text-secondary);
+}
+
+.extra-box__feedback--success {
+  background: rgba(13, 148, 136, 0.18);
+  border-color: rgba(45, 212, 191, 0.28);
+  color: #a7f3d0;
+}
+
+.extra-box__feedback--error {
+  background: rgba(190, 18, 60, 0.18);
+  border-color: rgba(244, 63, 94, 0.28);
+  color: #fecdd3;
+}
+
+.extra-box__feedback--info {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(96, 165, 250, 0.28);
+  color: #bfdbfe;
+}
+
+.extra-box-form__button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(0.45rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale)) calc(1.4rem * var(--spacing-scale));
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.24), rgba(14, 165, 233, 0.08));
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease,
+    background 140ms ease;
+}
+
+.extra-box-form__button:hover,
+.extra-box-form__button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 calc(10px * var(--elevation-scale)) calc(24px * var(--elevation-scale))
+    rgba(14, 165, 233, 0.18);
+}
+
+.extra-box-form__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+}
+
+.extra-box-form__button .extra-box-form__button-progress {
+  display: none;
+}
+
+.extra-box-form__button[data-loading='true'] .extra-box-form__button-label {
+  display: none;
+}
+
+.extra-box-form__button[data-loading='true'] .extra-box-form__button-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(0.35rem * var(--spacing-scale));
+}
+
+.extra-box-form__note {
+  margin: 0;
+  font-size: clamp(calc(0.78rem * var(--font-scale)),
+      calc((0.74rem + 0.25vw) * var(--font-scale)), calc(0.9rem * var(--font-scale)));
+  color: var(--text-muted);
+}
+
+.extra-box-reward {
+  min-height: 120px;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(14, 165, 233, 0.3);
+  background: rgba(8, 15, 35, 0.65);
+  display: grid;
+  place-items: center;
+  padding: calc(1rem * var(--spacing-scale));
+  font-size: clamp(calc(0.82rem * var(--font-scale)),
+      calc((0.78rem + 0.25vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+  color: rgba(148, 163, 184, 0.85);
+  text-align: center;
+}
+
 .page__footer {
   padding: calc(2.5rem * var(--spacing-scale)) calc(1.6rem * var(--spacing-scale))
     calc(3rem * var(--spacing-scale));

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
           <button type="button" class="quick-nav__button" data-scroll-target="player-stats">
             Player stats
           </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="extra-box">
+            Extra box
+          </button>
         </div>
       </nav>
 
@@ -102,12 +105,133 @@
             </div>
           </div>
         </section>
+
+        <section id="extra-box" class="panel" aria-labelledby="extra-box-title">
+          <div class="panel__header">
+            <h2 id="extra-box-title" class="panel__title">Extra Box</h2>
+            <span class="panel__subtitle"
+              >Watch a rewarded ad to request an additional box for the latest leaderboard day</span
+            >
+          </div>
+
+          <!--
+            Extra box feature container. The card below holds the rewarded flow, the banner ads,
+            and the form that connects to Firebase. Comments describe the required integration steps
+            in detail so that the feature can be configured without reverse engineering the JS file.
+          -->
+          <article class="extra-box-card" aria-live="polite">
+            <div class="extra-box-card__ads">
+              <!--
+                Google Ads banner #1.
+                Replace the data-ad-client and data-ad-slot values with your AdSense identifiers.
+                The ads are activated programmatically in app.js once the Google Ads script loads.
+              -->
+              <div class="ads-banner">
+                <ins
+                  class="adsbygoogle"
+                  style="display: block"
+                  data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+                  data-ad-slot="0000000001"
+                  data-ad-format="auto"
+                  data-full-width-responsive="true"
+                ></ins>
+              </div>
+
+              <!--
+                Google Ads banner #2 – works the same way as the first banner. Use a dedicated
+                slot ID so that both placements can be reported independently in your AdSense UI.
+              -->
+              <div class="ads-banner ads-banner--secondary">
+                <ins
+                  class="adsbygoogle"
+                  style="display: block"
+                  data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+                  data-ad-slot="0000000002"
+                  data-ad-format="auto"
+                  data-full-width-responsive="true"
+                ></ins>
+              </div>
+            </div>
+
+            <form id="extra-box-form" class="extra-box-form" novalidate>
+              <div class="extra-box-form__field">
+                <label for="extra-box-player">
+                  Player name
+                  <input
+                    type="text"
+                    id="extra-box-player"
+                    name="extra-box-player"
+                    placeholder="e.g. player1"
+                    autocomplete="off"
+                    list="player-suggestions"
+                    required
+                  />
+                </label>
+              </div>
+
+              <!-- Summary row showing the extra box count that comes from Firebase -->
+              <div class="extra-box-form__summary" role="status" aria-live="polite">
+                <span class="extra-box-form__summary-label"
+                  >Extra boxes for Day <span id="extra-box-day-label">—</span>:</span
+                >
+                <strong id="extra-box-count-value" class="extra-box-form__summary-value">0</strong>
+              </div>
+
+              <!--
+                Feedback element that displays info, error, and success messages. The JS toggles the
+                modifier classes (e.g. extra-box__feedback--success) to style the message properly.
+              -->
+              <p id="extra-box-feedback" class="extra-box__feedback" hidden></p>
+
+              <button type="submit" id="extra-box-request" class="extra-box-form__button">
+                <span class="extra-box-form__button-label">Request box</span>
+                <span class="extra-box-form__button-progress" aria-hidden="true">Processing…</span>
+              </button>
+
+              <p class="extra-box-form__note">
+                You will be asked to watch a rewarded Google ad. After the ad finishes the Firebase
+                database is updated and the page reloads to fetch fresh banners.
+              </p>
+            </form>
+
+            <!--
+              Rewarded ad container. Attach your Google Publisher Tag or AdSense rewarded ad
+              implementation to the global window.requestExtraBoxAd handler (see the script below)
+              so that the JS can tell when the user finished watching an ad.
+            -->
+            <div id="extra-box-reward-ad" class="extra-box-reward" aria-live="polite"></div>
+          </article>
+        </section>
       </main>
 
       <footer class="page__footer">
         Data refreshes daily.
       </footer>
     </div>
+
+    <!--
+      Configuration block for the extra box feature.
+      1. Replace EXTRA_BOX_FIREBASE_CONFIG with your Firebase project credentials (projectId, apiKey, etc.).
+      2. Implement window.requestExtraBoxAd so that it shows a rewarded Google ad and calls onComplete()
+         once the reward is granted. See app.js for the expected callback contract.
+      3. Update the Google Ads banner slots above with production ad unit IDs.
+    -->
+    <script>
+      window.EXTRA_BOX_FIREBASE_CONFIG = null; // TODO: Paste your Firebase configuration object here.
+
+      // TODO: Implement the rewarded ad logic and call onComplete() after the reward is issued.
+      // window.requestExtraBoxAd = ({ container, onComplete, onError }) => {
+      //   // Example stub – replace with Google Ad Manager / AdSense rewarded implementation.
+      //   onComplete();
+      // };
+    </script>
+
+    <!-- Google Ads loader. Replace the client ID with your own publisher account identifier. -->
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX"
+      crossorigin="anonymous"
+    ></script>
 
     <script src="assets/js/app.js" type="module"></script>
   </body>


### PR DESCRIPTION
## Summary
- add an Extra Box panel with Google Ads banner slots, a rewarded-ad workflow, and detailed setup comments
- style the new panel to match the existing mobile-first layout and provide feedback states for the rewarded flow
- integrate Firebase-powered counting logic, reuse the player suggestion list, and prime Google Ads placeholders

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d2d9c20534832fa3da55e79a0d2df3