### PR TITLE
Add Extra Box flow with Firebase and ad scaffolding

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -559,6 +559,216 @@ a:focus {
   border: 1px solid rgba(148, 163, 184, 0.24);
 }
 
+/*
+  Extra Box panel styles -----------------------------------------------------
+  The following rules provide a flexible layout for the Extra Box section with
+  two banner ads, one rewarded ad container, and the request form. The grid
+  collapses nicely on smaller screens while keeping the futuristic aesthetic of
+  the rest of the page.
+*/
+
+.panel--extra {
+  /* Slightly brighter surface to make the monetization block stand out. */
+  background: linear-gradient(180deg, rgba(12, 18, 30, 0.92) 0%, rgba(12, 18, 30, 0.78) 100%);
+  border-color: rgba(56, 189, 248, 0.28);
+  display: grid;
+  gap: calc(1.8rem * var(--spacing-scale));
+}
+
+.extra-box__layout {
+  display: grid;
+  gap: calc(1.6rem * var(--spacing-scale));
+}
+
+@media (min-width: 768px) {
+  .extra-box__layout {
+    /* Two columns on tablets/desktops: ads left, content right. */
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.2fr);
+    align-items: stretch;
+  }
+}
+
+.extra-box__ads {
+  display: grid;
+  gap: calc(1rem * var(--spacing-scale));
+}
+
+.ad-slot {
+  position: relative;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(56, 189, 248, 0.4);
+  background: rgba(8, 15, 35, 0.65);
+  min-height: clamp(120px, 22vw, 180px);
+  padding: calc(1.2rem * var(--spacing-scale));
+  display: grid;
+  place-items: center;
+  text-align: center;
+  overflow: hidden;
+}
+
+.ad-slot--reward {
+  min-height: clamp(160px, 32vw, 220px);
+  border-style: solid;
+  border-color: rgba(14, 165, 233, 0.45);
+  background: rgba(12, 23, 50, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.18);
+}
+
+.ad-slot--reward[data-ad-state='loading']::after,
+.ad-slot--reward[data-ad-state='simulated']::after {
+  content: attr(data-ad-message);
+  font-size: clamp(calc(0.82rem * var(--font-scale)), calc((0.78rem + 0.3vw) * var(--font-scale)),
+      calc(0.96rem * var(--font-scale)));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(125, 211, 252, 0.85);
+}
+
+.ad-slot__placeholder {
+  margin: 0;
+  font-size: clamp(calc(0.78rem * var(--font-scale)), calc((0.74rem + 0.2vw) * var(--font-scale)),
+      calc(0.92rem * var(--font-scale)));
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.66);
+}
+
+.extra-box__content {
+  display: grid;
+  gap: calc(1.4rem * var(--spacing-scale));
+  background: rgba(8, 13, 30, 0.78);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  padding: calc(1.5rem * var(--spacing-scale));
+  box-shadow: inset 0 0 0 1px rgba(8, 145, 178, 0.18);
+}
+
+.extra-box__form {
+  display: grid;
+  gap: calc(1rem * var(--spacing-scale));
+}
+
+.extra-box__label {
+  display: grid;
+  gap: calc(0.5rem * var(--spacing-scale));
+  font-size: clamp(calc(0.85rem * var(--font-scale)), calc((0.8rem + 0.25vw) * var(--font-scale)),
+      calc(0.95rem * var(--font-scale)));
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.extra-box__label input {
+  appearance: none;
+  width: 100%;
+  padding: clamp(calc(0.75rem * var(--spacing-scale)), calc((0.7rem + 0.35vw) * var(--spacing-scale)),
+      calc(0.95rem * var(--spacing-scale)))
+    clamp(calc(1rem * var(--spacing-scale)), calc((0.9rem + 0.5vw) * var(--spacing-scale)),
+      calc(1.35rem * var(--spacing-scale)));
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text-primary);
+  font-size: clamp(calc(1rem * var(--font-scale)), calc((0.95rem + 0.4vw) * var(--font-scale)),
+      calc(1.15rem * var(--font-scale)));
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.extra-box__label input::placeholder {
+  color: rgba(148, 163, 184, 0.5);
+  font-weight: 500;
+}
+
+.extra-box__label input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 calc(3px * var(--spacing-scale)) rgba(14, 165, 233, 0.2);
+}
+
+.extra-box__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(0.5rem * var(--spacing-scale));
+  padding: calc(0.9rem * var(--spacing-scale)) calc(1.1rem * var(--spacing-scale));
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(6, 182, 212, 0.08);
+}
+
+.extra-box__summary-label {
+  font-size: clamp(calc(0.92rem * var(--font-scale)), calc((0.88rem + 0.24vw) * var(--font-scale)),
+      calc(1.05rem * var(--font-scale)));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(125, 211, 252, 0.9);
+}
+
+.extra-box__summary-value {
+  font-size: clamp(calc(1.6rem * var(--font-scale)), calc((1.45rem + 0.9vw) * var(--font-scale)),
+      calc(1.9rem * var(--font-scale)));
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.extra-box__status {
+  margin: 0;
+  font-size: clamp(calc(0.85rem * var(--font-scale)), calc((0.8rem + 0.3vw) * var(--font-scale)),
+      calc(0.98rem * var(--font-scale)));
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.extra-box__status[data-state='success'] {
+  color: #bbf7d0;
+}
+
+.extra-box__status[data-state='error'] {
+  color: #fda4af;
+}
+
+.extra-box__button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: clamp(calc(0.75rem * var(--spacing-scale)), calc((0.7rem + 0.4vw) * var(--spacing-scale)),
+      calc(1rem * var(--spacing-scale)))
+    clamp(calc(1.6rem * var(--spacing-scale)), calc((1.4rem + 1vw) * var(--spacing-scale)),
+      calc(2.2rem * var(--spacing-scale)));
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.55), rgba(8, 145, 178, 0.45));
+  color: var(--text-primary);
+  font-size: clamp(calc(1rem * var(--font-scale)), calc((0.95rem + 0.4vw) * var(--font-scale)),
+      calc(1.12rem * var(--font-scale)));
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(0.5rem * var(--spacing-scale));
+}
+
+.extra-box__button:hover,
+.extra-box__button:focus-visible {
+  outline: none;
+  transform: translateY(calc(-1px * var(--spacing-scale)));
+  box-shadow: 0 calc(14px * var(--elevation-scale)) calc(28px * var(--elevation-scale))
+    rgba(8, 145, 178, 0.35);
+}
+
+.extra-box__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
 @media (min-width: 560px) {
   :root {
     --layout-max-width: 540px;

--- a/assets/js/extra-box-config.example.js
+++ b/assets/js/extra-box-config.example.js
@@ -1,0 +1,85 @@
+/**
+ * Extra Box configuration example
+ * --------------------------------
+ * 1. Duplicate this file, rename the copy to `assets/js/extra-box-config.js`,
+ *    and load it from `index.html` before `assets/js/app.js`.
+ * 2. Replace all placeholder values with your Firebase + Google Ads details.
+ * 3. Never commit real credentials. Keep secrets in deployment environments.
+ */
+
+window.EXTRA_BOX_CONFIG = {
+  /**
+   * Firebase Realtime Database URL
+   * -------------------------------
+   * Use the "Database" tab inside the Firebase console and copy the REST
+   * endpoint that ends with `.firebasedatabase.app`. Example:
+   * https://your-project-id-default-rtdb.europe-west1.firebasedatabase.app
+   */
+  realtimeDatabaseUrl: 'https://your-project-id-default-rtdb.europe-west1.firebasedatabase.app',
+
+  /**
+   * extraBoxesPath
+   * ---------------
+   * The JSON path that stores the per-player box counters. Keeping it short
+   * helps with security rules: e.g. `/extraBoxes` or `/prod/extraBoxes`.
+   */
+  extraBoxesPath: 'extraBoxes',
+
+  /**
+   * authToken (optional but recommended)
+   * ------------------------------------
+   * Provide either a Firebase Database Secret (legacy) or an Auth token created
+   * through a Cloud Function. Example: use a Cloud Function to mint a custom
+   * token that only allows writes to `/extraBoxes/{playerId}`.
+   */
+  authToken: 'REPLACE_WITH_DATABASE_SECRET_OR_CUSTOM_TOKEN',
+
+  /**
+   * buildKey(playerName)
+   * --------------------
+   * Firebase paths may not contain `.`, `#`, `$`, `[`, or `]`. The helper below
+   * converts the typed name into a safe key. Adjust if you keep spaces, etc.
+   */
+  buildKey(playerName) {
+    return playerName.trim().toLowerCase().replace(/[.#$/\[\]]/g, '_');
+  },
+
+  /**
+   * loadRewardedAd({ container, playerName })
+   * -----------------------------------------
+   * Implement the Google Ads rewarded ad flow here. The function must return a
+   * Promise that resolves only after the user watched the ad to completion.
+   *
+   * Example with Google Publisher Tag (GPT) rewarded ads:
+   *
+   *   loadRewardedAd: ({ container, playerName }) => {
+   *     return new Promise((resolve, reject) => {
+   *       const slot = window.googletag.defineOutOfPageSlot(
+   *         '/123456789/extra_box_rewarded',
+   *         window.googletag.enums.OutOfPageFormat.REWARDED,
+   *       );
+   *       if (!slot) {
+   *         reject(new Error('Rewarded slot could not be created.'));
+   *         return;
+   *       }
+   *       slot.addService(window.googletag.pubads());
+   *
+   *       window.googletag.pubads().addEventListener('rewardedSlotReady', () => {
+   *         slot.show();
+   *       });
+   *       window.googletag.pubads().addEventListener('rewardedSlotClosed', resolve);
+   *       window.googletag.enableServices();
+   *       window.googletag.display(slot);
+   *     });
+   *   }
+   *
+   * For Google AdSense Auto ads, use a full-screen overlay with a manual
+   * close handler and call `resolve()` once the ad fires the reward event.
+   */
+  async loadRewardedAd({ container, playerName }) {
+    console.info('Simulating rewarded ad for', playerName);
+    container.setAttribute('data-ad-state', 'loading');
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    container.removeAttribute('data-ad-state');
+  },
+};

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
           <button type="button" class="quick-nav__button" data-scroll-target="player-stats">
             Player stats
           </button>
+          <button type="button" class="quick-nav__button" data-scroll-target="extra-box">
+            Extra box
+          </button>
         </div>
       </nav>
 
@@ -102,6 +105,87 @@
             </div>
           </div>
         </section>
+
+        <section id="extra-box" class="panel panel--extra" aria-labelledby="extra-box-title">
+          <div class="panel__header">
+            <h2 id="extra-box-title" class="panel__title">Extra Box</h2>
+            <span class="panel__subtitle">Enter your name to get an extra box</span>
+          </div>
+
+          <div class="extra-box__layout">
+            <aside class="extra-box__ads" aria-label="Promotional banners">
+              <div class="ad-slot" id="extra-box-banner-top" data-ad-slot="banner-top">
+                <!--
+                  Google Ads banner placeholder (top)
+                  Replace the placeholder <p> with the AdSense or Google Ad Manager tag, for example:
+                  <ins class="adsbygoogle"
+                       style="display:block"
+                       data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+                       data-ad-slot="1234567890"
+                       data-ad-format="auto"
+                       data-full-width-responsive="true"></ins>
+                  <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+                -->
+                <p class="ad-slot__placeholder">Add your 1st Google Ads banner code here.</p>
+              </div>
+
+              <div class="ad-slot" id="extra-box-banner-bottom" data-ad-slot="banner-bottom">
+                <!--
+                  Google Ads banner placeholder (bottom)
+                  Use a second ad unit ID so that two banners can rotate independently.
+                  Copy the Google snippet here once your ad units are approved.
+                -->
+                <p class="ad-slot__placeholder">Add your 2nd Google Ads banner code here.</p>
+              </div>
+            </aside>
+
+            <div class="extra-box__content">
+              <form id="extra-box-form" class="extra-box__form" autocomplete="off">
+                <label for="extra-player-name" class="extra-box__label">
+                  Player name
+                  <input
+                    type="search"
+                    id="extra-player-name"
+                    name="extra-player-name"
+                    placeholder="e.g. player1"
+                    list="player-suggestions"
+                    autocomplete="off"
+                    required
+                  />
+                </label>
+
+                <div class="extra-box__summary" aria-live="polite">
+                  <span class="extra-box__summary-label">Extra boxes for Day <strong id="extra-box-day">—</strong></span>
+                  <span class="extra-box__summary-value" id="extra-box-count">0</span>
+                </div>
+
+                <p class="extra-box__status" id="extra-box-status">
+                  Enter your name and connect Firebase to show existing extra boxes.
+                </p>
+
+                <button type="submit" class="extra-box__button" id="extra-box-request">
+                  Get an extra box
+                </button>
+              </form>
+
+              <div
+                class="ad-slot ad-slot--reward"
+                id="rewarded-ad-container"
+                data-ad-slot="rewarded"
+                data-ad-message="Loading rewarded ad…"
+                aria-live="polite"
+              >
+                <!--
+                  Rewarded Google Ad placeholder
+                  Implement the rewarded ad with Google Ad Manager or AdMob and call
+                  window.EXTRA_BOX_CONFIG.loadRewardedAd(options) as documented in assets/js/extra-box-config.example.js.
+                  The JavaScript will wait for your promise to resolve before granting a box.
+                -->
+                <p class="ad-slot__placeholder">Rewarded ad loads here before a box is granted.</p>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
 
       <footer class="page__footer">
@@ -109,6 +193,13 @@
       </footer>
     </div>
 
+    <!--
+      ⚠️ Important: Define window.EXTRA_BOX_CONFIG with your Firebase + Google Ads settings
+      before loading assets/js/app.js. Create a copy of assets/js/extra-box-config.example.js,
+      update the credentials, and include it here:
+
+      <script src="assets/js/extra-box-config.js"></script>
+    -->
     <script src="assets/js/app.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an Extra Box navigation tab with banner and rewarded ad placeholders and a form to request boxes
- style the new panel to match the existing aesthetic and highlight the monetization area
- implement frontend logic for loading Firebase counts, handling rewarded ads, and updating totals with detailed comments and configuration hooks
- provide an example configuration file explaining how to connect Firebase and Google Ads

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2d9c20534832fa3da55e79a0d2df3