### PR TITLE
Optimize mobile stats views with lazy loading

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -236,6 +236,10 @@ a:focus {
   backdrop-filter: blur(calc(18px * var(--elevation-scale)));
 }
 
+.panel[hidden] {
+  display: none !important;
+}
+
 .panel__header {
   display: grid;
   gap: calc(0.55rem * var(--spacing-scale));
@@ -257,9 +261,76 @@ a:focus {
   color: var(--text-muted);
 }
 
+.panel__notice {
+  margin: 0 0 calc(1.1rem * var(--spacing-scale));
+  padding: calc(0.85rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  background: rgba(250, 204, 21, 0.1);
+  color: #fcd34d;
+  font-size: clamp(calc(0.85rem * var(--font-scale)),
+      calc((0.8rem + 0.28vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+  line-height: 1.6;
+}
+
 .card-grid {
   display: grid;
   gap: calc(1.1rem * var(--spacing-scale));
+}
+
+.loading-block {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(0.75rem * var(--spacing-scale));
+  padding: calc(0.8rem * var(--spacing-scale)) calc(1.1rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.72);
+  margin-bottom: calc(1.2rem * var(--spacing-scale));
+  color: var(--text-secondary);
+  font-size: clamp(calc(0.82rem * var(--font-scale)),
+      calc((0.76rem + 0.3vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+}
+
+.loading-block[hidden] {
+  display: none;
+}
+
+.spinner {
+  width: clamp(1.25rem, 3.6vw, 1.75rem);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.4);
+  border-top-color: rgba(14, 165, 233, 0.85);
+  animation: spin 0.85s linear infinite;
+}
+
+.loading-block__label {
+  white-space: nowrap;
+}
+
+.inline-loader {
+  display: flex;
+  align-items: center;
+  gap: calc(0.65rem * var(--spacing-scale));
+  color: var(--text-muted);
+  font-size: clamp(calc(0.8rem * var(--font-scale)),
+      calc((0.74rem + 0.28vw) * var(--font-scale)), calc(0.92rem * var(--font-scale)));
+  padding: calc(0.3rem * var(--spacing-scale)) 0;
+}
+
+.inline-loader .spinner {
+  width: clamp(0.9rem, 2.6vw, 1.1rem);
+  border-width: 2px;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .day-card {
@@ -370,6 +441,18 @@ a:focus {
 
 .details-button[aria-expanded='true']::after {
   transform: rotate(90deg);
+}
+
+.heavy-warning {
+  margin: 0;
+  padding: calc(0.75rem * var(--spacing-scale));
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(250, 204, 21, 0.38);
+  background: rgba(250, 204, 21, 0.08);
+  color: #facc15;
+  font-size: clamp(calc(0.78rem * var(--font-scale)),
+      calc((0.72rem + 0.24vw) * var(--font-scale)), calc(0.9rem * var(--font-scale)));
+  line-height: 1.55;
 }
 
 .collapse {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,392 +1,361 @@
+/**
+ * High level controller for the Ball Crusher stats dashboard.
+ * The previous version rendered every player eagerly and drove a canvas animation.
+ * That looked nice, but on huge data dumps it produced thousands of DOM nodes
+ * and expensive layout/paint work up-front. This file now focuses on:
+ *   1. Fetching once and showing only lightweight winner previews initially.
+ *   2. Lazy-rendering the heavy leaderboards when the viewer explicitly asks.
+ *   3. Preparing player search infrastructure only when the Player tab is opened.
+ *   4. Keeping every function small, documented, and easy to tweak.
+ */
+
 const DATA_URL = 'data/day_stats.json';
 
-const root = document.documentElement;
+// --- DOM lookups ---------------------------------------------------------------------------
+
 const openStatsGrid = document.getElementById('open-stats-grid');
+const openStatsLoading = document.getElementById('open-stats-loading');
 const playerSearchInput = document.getElementById('player-search');
 const playerResultsContainer = document.getElementById('player-results');
 const playerSuggestions = document.getElementById('player-suggestions');
 const sortFieldSelect = document.getElementById('sort-field');
 const sortOrderSelect = document.getElementById('sort-order');
-const canvas = document.getElementById('statsCanvas');
-const quickNav = document.querySelector('.quick-nav');
-const quickNavButtons = quickNav
-  ? Array.from(quickNav.querySelectorAll('.quick-nav__button'))
-  : [];
+const quickNavButtons = Array.from(document.querySelectorAll('.quick-nav__button'));
+const viewSections = Array.from(document.querySelectorAll('[data-view]'));
 
-const lastAppliedMetrics = {
-  width: 0,
-  height: 0,
-  orientation: '',
+// --- Shared state --------------------------------------------------------------------------
+
+const state = {
+  /** Sorted list of day objects exactly as received from the JSON file. */
+  days: [],
+  /** Quick lookup by day number so we can hydrate cards lazily. */
+  dayLookup: new Map(),
+  /** Cache for the per-player aggregates used in the Player Stats view. */
+  playerIndex: new Map(),
+  /** Flag that prevents building the heavy index multiple times. */
+  playerIndexReady: false,
+  /** Stores the player currently shown in the Player Stats cards. */
+  currentPlayer: null,
 };
 
-let playerIndex = new Map();
-let currentPlayer = null;
-let winnerTimeline = [];
-let canvasAnimationId = null;
-let canvasResizeHandler = null;
-let quickNavObserver = null;
-let metricsFrameId = null;
+// Copy we reuse in multiple warnings / loaders.
+const HEAVY_VIEW_WARNING =
+  'Loading the full leaderboard may strain your device. Continue only if you need the details.';
 
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
+// --- View helpers --------------------------------------------------------------------------
 
-function resolveBoxCount(player) {
-  const rawValue = player?.boxs;
-  if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue > 0) {
-    return Math.round(rawValue);
-  }
-  if (typeof rawValue === 'string') {
-    const parsed = Number.parseInt(rawValue, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
-  }
-  return 1;
-}
-
-function resolveViewportMeasure() {
-  const viewport = window.visualViewport;
-  const widthCandidates = [
-    viewport?.width,
-    window.innerWidth,
-    document.documentElement.clientWidth,
-    typeof screen !== 'undefined' ? screen.width : undefined,
-  ];
-  const heightCandidates = [
-    window.innerHeight,
-    document.documentElement.clientHeight,
-    viewport?.height,
-    typeof screen !== 'undefined' ? screen.height : undefined,
-  ];
-  const width = widthCandidates.find((value) => Number.isFinite(value) && value > 0) || 0;
-  const layoutHeight = heightCandidates.find((value) => Number.isFinite(value) && value > 0) || 0;
-  return { viewport, width, layoutHeight };
-}
-
-function applyMobileMetrics({ force = false } = {}) {
-  const { viewport, width: rawWidth, layoutHeight } = resolveViewportMeasure();
-  const rawHeight = viewport?.height && viewport.height > 0 ? viewport.height : layoutHeight;
-  const width = clamp(rawWidth, 280, 1100);
-  const measuredHeight = clamp(layoutHeight || rawHeight || width * 1.6, 400, 1700);
-  const orientation = width >= measuredHeight ? 'landscape' : 'portrait';
-  const minPortraitHeight = width * 1.55;
-  const minLandscapeHeight = width * 0.75;
-  const heightFloor = orientation === 'portrait' ? minPortraitHeight : minLandscapeHeight;
-  const stableHeight = Math.max(measuredHeight, heightFloor);
-  const height = clamp(stableHeight, 420, 1800);
-
-  const widthChanged = Math.abs(width - lastAppliedMetrics.width) >= 0.75;
-  const heightChanged = Math.abs(height - lastAppliedMetrics.height) >= 120;
-  const orientationChanged = orientation !== lastAppliedMetrics.orientation;
-
-  if (!force && !widthChanged && !orientationChanged && !heightChanged) {
-    const vh = (layoutHeight || lastAppliedMetrics.height || height) * 0.01;
-    root.style.setProperty('--vh', `${vh.toFixed(4)}px`);
-    root.style.setProperty('--vw', `${(width * 0.01).toFixed(4)}px`);
-    return;
-  }
-
-  lastAppliedMetrics.width = width;
-  lastAppliedMetrics.height = height;
-  lastAppliedMetrics.orientation = orientation;
-
-  const minDimension = Math.min(width, height);
-  const maxDimension = Math.max(width, height);
-  const pixelRatio = window.devicePixelRatio || 1;
-
-  const baseWidth = 390;
-  const baseHeight = 844;
-  const baseDiagonal = Math.hypot(baseWidth, baseHeight);
-  const widthScale = width / baseWidth;
-  const heightScale = height / baseHeight;
-  const diagonalScale = Math.hypot(width, height) / baseDiagonal;
-  const averagedScale = (widthScale * 2 + heightScale + diagonalScale) / 4;
-  const densityCompensation = clamp(Math.sqrt(pixelRatio) / 1.45, 0.75, 1.15);
-  const fontScale = clamp(averagedScale / densityCompensation, 0.85, 1.26);
-  const spacingScale = clamp(
-    (widthScale * 0.68 + heightScale * 0.32) * (orientation === 'landscape' ? 0.9 : 1.05),
-    0.78,
-    1.36,
-  );
-  const radiusScale = clamp(widthScale * 0.92, 0.72, 1.28);
-  const elevationScale = clamp(averagedScale * (orientation === 'landscape' ? 0.88 : 1.08), 0.8, 1.38);
-  const layoutWidth = clamp(
-    width * (orientation === 'landscape' ? 0.86 : 0.95),
-    Math.min(width, 320),
-    Math.min(width * 0.98, 760),
-  );
-
-  root.style.setProperty('--scale', fontScale.toFixed(4));
-  root.style.setProperty('--font-scale', fontScale.toFixed(4));
-  root.style.setProperty('--spacing-scale', spacingScale.toFixed(4));
-  root.style.setProperty('--radius-scale', radiusScale.toFixed(4));
-  root.style.setProperty('--elevation-scale', elevationScale.toFixed(4));
-  root.style.setProperty('--layout-max-width', `${layoutWidth.toFixed(2)}px`);
-  root.style.setProperty('--viewport-width', `${width.toFixed(2)}px`);
-  root.style.setProperty('--viewport-height', `${height.toFixed(2)}px`);
-  root.style.setProperty('--viewport-min', `${minDimension.toFixed(2)}px`);
-  root.style.setProperty('--viewport-max', `${maxDimension.toFixed(2)}px`);
-  root.style.setProperty('--pixel-ratio', pixelRatio.toFixed(3));
-  const vh = (layoutHeight || height) * 0.01;
-  root.style.setProperty('--vh', `${vh.toFixed(4)}px`);
-  root.style.setProperty('--vw', `${(width * 0.01).toFixed(4)}px`);
-}
-
-function scheduleMobileMetricsUpdate() {
-  if (metricsFrameId) {
-    return;
-  }
-  metricsFrameId = requestAnimationFrame(() => {
-    metricsFrameId = null;
-    applyMobileMetrics();
+/**
+ * Switch between the "Open stats" and "Player stats" views.
+ * We rely on hidden sections instead of scrolling to keep the DOM short and predictable.
+ */
+function showView(targetId) {
+  viewSections.forEach((section) => {
+    const shouldShow = section.dataset.view === targetId;
+    section.hidden = !shouldShow;
   });
-}
 
-applyMobileMetrics({ force: true });
-window.addEventListener('resize', scheduleMobileMetricsUpdate, { passive: true });
-window.addEventListener('orientationchange', scheduleMobileMetricsUpdate, { passive: true });
-if (window.visualViewport) {
-  window.visualViewport.addEventListener('resize', scheduleMobileMetricsUpdate, { passive: true });
-}
-
-function setActiveQuickNav(targetId) {
-  if (!quickNavButtons.length) {
-    return;
-  }
   quickNavButtons.forEach((button) => {
-    const isActive = button.dataset.scrollTarget === targetId;
+    const isActive = button.dataset.viewTarget === targetId;
     button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
+
+  if (targetId === 'players') {
+    // Building the player index can be expensive, so defer it until this point.
+    ensurePlayerIndex();
+  }
 }
 
-function setupQuickNav() {
-  if (!quickNav || !quickNavButtons.length) {
-    return;
-  }
+// Activate the first view immediately.
+showView('open');
 
-  quickNav.addEventListener('click', (event) => {
-    const button = event.target.closest('.quick-nav__button');
-    if (!button) {
-      return;
+// Keep the navigation buttons wired to the view switcher.
+quickNavButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const target = button.dataset.viewTarget;
+    if (target) {
+      showView(target);
     }
-    const targetId = button.dataset.scrollTarget;
-    const target = targetId ? document.getElementById(targetId) : null;
-    if (!target) {
-      return;
-    }
-
-    const navHeight = quickNav.getBoundingClientRect().height;
-    const spacingScale = parseFloat(getComputedStyle(root).getPropertyValue('--spacing-scale')) || 1;
-    const topOffset = navHeight + 12 * spacingScale;
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const behavior = prefersReducedMotion ? 'auto' : 'smooth';
-    const targetBounds = target.getBoundingClientRect();
-    const absoluteTop = (window.pageYOffset || document.documentElement.scrollTop || 0) + targetBounds.top;
-    const finalTop = Math.max(absoluteTop - topOffset, 0);
-
-    window.scrollTo({ top: finalTop, behavior });
-    setActiveQuickNav(targetId);
   });
+});
 
-  const observedSections = quickNavButtons
-    .map((button) => document.getElementById(button.dataset.scrollTarget || ''))
-    .filter(Boolean);
-
-  if (quickNavObserver) {
-    quickNavObserver.disconnect();
-  }
-
-  if (observedSections.length) {
-    setActiveQuickNav(observedSections[0].id);
-    quickNavObserver = new IntersectionObserver(
-      (entries) => {
-        const visibleEntries = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
-        if (!visibleEntries.length) {
-          return;
-        }
-        const topEntry = visibleEntries[0];
-        setActiveQuickNav(topEntry.target.id);
-      },
-      {
-        rootMargin: '-48% 0px -46% 0px',
-        threshold: [0.25, 0.5, 0.75],
-      },
-    );
-
-    observedSections.forEach((section) => quickNavObserver.observe(section));
-  }
+/**
+ * Convenience helper to show or hide the top level loading banner in the Open Stats view.
+ */
+function setOpenStatsLoading(isLoading) {
+  if (!openStatsLoading) return;
+  openStatsLoading.hidden = !isLoading;
 }
 
-setupQuickNav();
+/**
+ * Ensure the player results container contains a friendly default message whenever
+ * no selection is active.
+ */
+function showPlayerIdleMessage() {
+  playerResultsContainer.innerHTML =
+    '<p class="no-results">Search for a player to see results.</p>';
+}
+
+// Prime the idle message before any data arrives.
+showPlayerIdleMessage();
+
+// --- Data loading --------------------------------------------------------------------------
 
 async function loadStats() {
+  setOpenStatsLoading(true);
   try {
     const response = await fetch(DATA_URL, { cache: 'no-cache' });
     if (!response.ok) {
       throw new Error(`Failed to load stats (${response.status})`);
     }
-    const data = await response.json();
-    if (!data || !Array.isArray(data.day_stats)) {
+
+    const payload = await response.json();
+    if (!payload || !Array.isArray(payload.day_stats)) {
       throw new Error('Unexpected data format');
     }
-    initialize(data.day_stats);
+
+    initialiseDays(payload.day_stats);
   } catch (error) {
     console.error(error);
     openStatsGrid.innerHTML = `<p class="no-results">${error.message}. Check the JSON endpoint.</p>`;
     playerResultsContainer.innerHTML = `<p class="no-results">${error.message}. Player search unavailable.</p>`;
+  } finally {
+    setOpenStatsLoading(false);
   }
 }
 
-function initialize(dayStats) {
-  const sortedDays = [...dayStats].sort((a, b) => b.day - a.day);
-  winnerTimeline = buildWinnerTimeline(sortedDays);
-  renderOpenStats(sortedDays);
-  buildPlayerIndex(sortedDays);
-  populatePlayerSuggestions();
-  startCanvasAnimation();
-}
+/**
+ * Store the sorted day list and render the lightweight preview cards.
+ */
+function initialiseDays(dayStats) {
+  // Sort once so the UI remains consistent even if the API changes order.
+  state.days = [...dayStats].sort((a, b) => b.day - a.day);
+  state.dayLookup.clear();
 
-function buildWinnerTimeline(days) {
-  return days
-    .map((day) => {
-      const winner = [...day.players].sort((a, b) => a.rank - b.rank)[0];
-      if (!winner) return null;
-      return {
-        day: day.day,
-        name: winner.name,
-        time: winner.time,
-        seconds: parseTimeToSeconds(winner.time),
-      };
-    })
-    .filter(Boolean)
-    .sort((a, b) => a.day - b.day);
-}
-
-function renderOpenStats(days) {
-  openStatsGrid.innerHTML = '';
-  if (!days.length) {
+  if (!state.days.length) {
     openStatsGrid.innerHTML = '<p class="no-results">No days available yet.</p>';
     return;
   }
 
-  days.forEach((day) => {
-    const card = document.createElement('article');
-    card.className = 'day-card';
-    card.setAttribute('role', 'listitem');
+  const fragment = document.createDocumentFragment();
+  state.days.forEach((day) => {
+    state.dayLookup.set(String(day.day), {
+      day,
+      // We only calculate the winner immediately; the rest is deferred.
+      winner: resolveWinner(day.players),
+      players: day.players,
+      sortedPlayers: null,
+      loaded: false,
+      warningAcknowledged: false,
+    });
 
-    const header = document.createElement('div');
-    header.className = 'day-card-content';
+    fragment.append(createDayCard(day));
+  });
 
-    const label = document.createElement('div');
-    label.className = 'day-label';
-    label.textContent = `Day ${day.day}`;
+  openStatsGrid.innerHTML = '';
+  openStatsGrid.append(fragment);
+}
 
-    const winnerInfo = document.createElement('div');
-    winnerInfo.className = 'winner';
-    const topPlayer = [...day.players].sort((a, b) => a.rank - b.rank)[0];
-    const winnerLink = document.createElement('a');
-    winnerLink.href = buildInstagramLink(topPlayer?.name);
-    winnerLink.target = '_blank';
-    winnerLink.rel = 'noopener noreferrer';
-    winnerLink.textContent = topPlayer ? topPlayer.name : '—';
-
-    const winnerLabel = document.createElement('span');
-    winnerLabel.textContent = 'Daily winner';
-    winnerInfo.append(winnerLink, winnerLabel);
-
-    if (topPlayer) {
-      const winnerRectangles = document.createElement('span');
-      winnerRectangles.className = 'winner-rectangles';
-      winnerRectangles.textContent = `Rectangles: ${resolveBoxCount(topPlayer)}`;
-      winnerInfo.append(winnerRectangles);
+/**
+ * Identify the first-place finisher without allocating additional arrays.
+ */
+function resolveWinner(players = []) {
+  let best = null;
+  players.forEach((player) => {
+    if (!best || Number(player.rank) < Number(best.rank)) {
+      best = player;
     }
+  });
+  return best;
+}
 
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'details-button';
-    button.textContent = 'More details';
-    button.setAttribute('aria-expanded', 'false');
+/**
+ * Build the lightweight day preview card that only contains the winner.
+ */
+function createDayCard(day) {
+  const record = state.dayLookup.get(String(day.day));
+  const winner = record?.winner;
 
-    header.append(label, winnerInfo, button);
+  const card = document.createElement('article');
+  card.className = 'day-card';
+  card.setAttribute('role', 'listitem');
+  card.dataset.day = String(day.day);
 
-    const collapse = document.createElement('div');
-    collapse.className = 'collapse';
-    const collapseId = `day-${day.day}-details`;
-    collapse.id = collapseId;
-    collapse.hidden = true;
-    button.setAttribute('aria-controls', collapseId);
+  const header = document.createElement('div');
+  header.className = 'day-card-content';
+
+  const label = document.createElement('div');
+  label.className = 'day-label';
+  label.textContent = `Day ${day.day}`;
+
+  const winnerInfo = document.createElement('div');
+  winnerInfo.className = 'winner';
+
+  const winnerLink = document.createElement('a');
+  winnerLink.href = buildInstagramLink(winner?.name);
+  winnerLink.target = '_blank';
+  winnerLink.rel = 'noopener noreferrer';
+  winnerLink.textContent = winner?.name ?? '—';
+
+  const winnerLabel = document.createElement('span');
+  winnerLabel.textContent = 'Daily winner';
+
+  winnerInfo.append(winnerLink, winnerLabel);
+
+  if (winner) {
+    const rectangles = document.createElement('span');
+    rectangles.className = 'winner-rectangles';
+    rectangles.textContent = `Rectangles: ${resolveBoxCount(winner)}`;
+    winnerInfo.append(rectangles);
+  }
+
+  const warning = document.createElement('p');
+  warning.className = 'heavy-warning';
+  warning.textContent = '⚠️ ' + HEAVY_VIEW_WARNING;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'details-button';
+  button.textContent = 'View more';
+  button.setAttribute('aria-expanded', 'false');
+
+  const collapse = document.createElement('div');
+  collapse.className = 'collapse';
+  collapse.hidden = true;
+
+  button.addEventListener('click', () => toggleDayDetails(day.day, button, collapse));
+
+  header.append(label, winnerInfo, warning, button);
+  card.append(header, collapse);
+  return card;
+}
+
+/**
+ * Handle opening/closing of the detailed leaderboard per day.
+ */
+function toggleDayDetails(dayNumber, button, collapse) {
+  const dayId = String(dayNumber);
+  const record = state.dayLookup.get(dayId);
+  if (!record) {
+    return;
+  }
+
+  if (!record.warningAcknowledged) {
+    const proceed = window.confirm(HEAVY_VIEW_WARNING);
+    if (!proceed) {
+      return;
+    }
+    record.warningAcknowledged = true;
+  }
+
+  const willOpen = collapse.hidden;
+
+  // Always keep only one heavy panel expanded to minimise DOM work.
+  if (willOpen) {
+    closeOtherDetails(dayId);
+  }
+
+  collapse.hidden = !willOpen;
+  collapse.classList.toggle('open', willOpen);
+  button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+  button.textContent = willOpen ? 'Hide details' : 'View more';
+
+  if (!willOpen) {
+    return;
+  }
+
+  if (!record.loaded) {
+    renderDayDetails(record, collapse);
+  }
+}
+
+/**
+ * Close every other expanded leaderboard so the DOM stays small.
+ */
+function closeOtherDetails(exceptDayId) {
+  document.querySelectorAll('.day-card .collapse.open').forEach((element) => {
+    const parentCard = element.closest('.day-card');
+    if (!parentCard) return;
+    const isSame = parentCard.dataset.day === exceptDayId;
+    if (isSame) return;
+
+    element.hidden = true;
+    element.classList.remove('open');
+    const toggle = parentCard.querySelector('.details-button');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.textContent = 'View more';
+    }
+  });
+}
+
+/**
+ * Render the heavy leaderboard list inside the collapse panel. We keep the logic isolated so
+ * it can be reused if the day data changes in the future.
+ */
+function renderDayDetails(record, container) {
+  container.innerHTML = '';
+
+  const loader = document.createElement('div');
+  loader.className = 'inline-loader';
+  loader.innerHTML =
+    '<span class="spinner" aria-hidden="true"></span><span>Loading leaderboard…</span>';
+  container.append(loader);
+
+  // Defer the actual rendering to the next frame so the spinner paints immediately.
+  requestAnimationFrame(() => {
+    if (!record.sortedPlayers) {
+      record.sortedPlayers = [...record.players].sort((a, b) => a.rank - b.rank);
+    }
 
     const list = document.createElement('ul');
     list.className = 'player-list';
 
-    [...day.players]
-      .sort((a, b) => a.rank - b.rank)
-      .forEach((player) => {
-        const item = document.createElement('li');
+    const fragment = document.createDocumentFragment();
+    record.sortedPlayers.forEach((player) => {
+      const item = document.createElement('li');
 
-        const left = document.createElement('div');
-        left.className = 'player-name';
-        left.innerHTML = `<strong>${ordinal(player.rank)}</strong> &nbsp; <a href="${buildInstagramLink(
-          player.name
-        )}" target="_blank" rel="noopener noreferrer">${player.name}</a>`;
+      const left = document.createElement('div');
+      left.className = 'player-name';
+      left.innerHTML = `<strong>${ordinal(player.rank)}</strong>&nbsp; <a href="${buildInstagramLink(
+        player.name,
+      )}" target="_blank" rel="noopener noreferrer">${player.name}</a>`;
 
-        const right = document.createElement('span');
-        right.className = 'player-time';
-        right.textContent = `Time: ${player.time} • Rectangles: ${resolveBoxCount(player)}`;
+      const right = document.createElement('span');
+      right.className = 'player-time';
+      right.textContent = `Time: ${player.time} • Rectangles: ${resolveBoxCount(player)}`;
 
-        item.append(left, right);
-        list.append(item);
-      });
-
-    collapse.append(list);
-
-    button.addEventListener('click', () => {
-      const isOpen = collapse.classList.toggle('open');
-      collapse.hidden = !isOpen;
-      button.setAttribute('aria-expanded', String(isOpen));
-      button.textContent = isOpen ? 'Hide details' : 'More details';
-
-      if (isOpen) {
-        document.querySelectorAll('.collapse.open').forEach((openSection) => {
-          if (openSection === collapse) return;
-          openSection.classList.remove('open');
-          openSection.hidden = true;
-          const toggle = openSection.previousElementSibling?.querySelector?.('.details-button');
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'false');
-            toggle.textContent = 'More details';
-          }
-        });
-
-        if (typeof collapse.scrollIntoView === 'function') {
-          requestAnimationFrame(() => {
-            collapse.scrollIntoView({ block: 'start', behavior: 'smooth' });
-          });
-        }
-      }
+      item.append(left, right);
+      fragment.append(item);
     });
 
-    card.append(header, collapse);
-    openStatsGrid.append(card);
+    list.append(fragment);
+    container.innerHTML = '';
+    container.append(list);
+    record.loaded = true;
   });
 }
 
-function buildPlayerIndex(days) {
-  playerIndex = new Map();
+// --- Player search -------------------------------------------------------------------------
 
-  days.forEach((day) => {
+/**
+ * Build the player index once. We prepare suggestion options and allow searching by name.
+ */
+function ensurePlayerIndex() {
+  if (state.playerIndexReady) {
+    return;
+  }
+
+  const index = new Map();
+  state.days.forEach((day) => {
     day.players.forEach((player) => {
       const key = player.name.trim().toLowerCase();
-      if (!playerIndex.has(key)) {
-        playerIndex.set(key, {
+      if (!index.has(key)) {
+        index.set(key, {
           name: player.name,
           records: [],
         });
       }
-      const entry = playerIndex.get(key);
+      const entry = index.get(key);
       entry.records.push({
         day: day.day,
         rank: player.rank,
@@ -396,55 +365,71 @@ function buildPlayerIndex(days) {
       });
     });
   });
+
+  state.playerIndex = index;
+  state.playerIndexReady = true;
+  populatePlayerSuggestions();
 }
 
+/**
+ * Populate the datalist used for the native autocomplete dropdown.
+ */
 function populatePlayerSuggestions() {
   playerSuggestions.innerHTML = '';
-  const sortedPlayers = Array.from(playerIndex.values())
+  const sortedPlayers = Array.from(state.playerIndex.values())
     .map((entry) => entry.name)
     .sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
 
+  const fragment = document.createDocumentFragment();
   sortedPlayers.forEach((name) => {
     const option = document.createElement('option');
     option.value = name;
-    playerSuggestions.append(option);
+    fragment.append(option);
   });
+
+  playerSuggestions.append(fragment);
 }
 
-function updatePlayerResults(options = {}) {
-  const { silentOnNoMatch = false } = options;
+/**
+ * Read the current search input and show the appropriate results.
+ */
+function updatePlayerResults({ silentOnNoMatch = false } = {}) {
   const query = playerSearchInput.value.trim();
   if (!query) {
-    currentPlayer = null;
-    playerResultsContainer.innerHTML = '<p class="no-results">Search for a player to see results.</p>';
+    state.currentPlayer = null;
+    showPlayerIdleMessage();
     return;
   }
 
+  ensurePlayerIndex();
+
   const normalized = query.toLowerCase();
-  let entry = playerIndex.get(normalized);
+  let entry = state.playerIndex.get(normalized);
 
   if (!entry && normalized.length >= 2) {
-    const partialMatches = Array.from(playerIndex.entries())
-      .map(([key, value]) => ({ key, value }))
-      .filter(({ key, value }) => value.name.toLowerCase().includes(normalized));
-
+    const partialMatches = Array.from(state.playerIndex.values()).filter((candidate) =>
+      candidate.name.toLowerCase().includes(normalized),
+    );
     if (partialMatches.length === 1) {
-      entry = partialMatches[0].value;
+      entry = partialMatches[0];
     }
   }
 
   if (!entry) {
-    currentPlayer = null;
+    state.currentPlayer = null;
     if (!silentOnNoMatch) {
       playerResultsContainer.innerHTML = `<p class="no-results">No results for "${query}".</p>`;
     }
     return;
   }
 
-  currentPlayer = entry;
+  state.currentPlayer = entry;
   renderPlayerResults(entry);
 }
 
+/**
+ * Render the cards for a specific player using the currently selected sort mode.
+ */
 function renderPlayerResults(entry) {
   const field = sortFieldSelect.value;
   const order = sortOrderSelect.value;
@@ -477,12 +462,14 @@ function renderPlayerResults(entry) {
   summary.textContent = `Showing ${count} ${dayLabel} for ${entry.name}.`;
   playerResultsContainer.append(summary);
 
+  const fragment = document.createDocumentFragment();
   sortedRecords.forEach((record) => {
     const card = document.createElement('article');
     card.className = 'player-result-card';
 
     const meta = document.createElement('div');
     meta.className = 'meta';
+
     const dayBadge = document.createElement('span');
     dayBadge.className = 'badge';
     dayBadge.textContent = `Day ${record.day}`;
@@ -496,9 +483,7 @@ function renderPlayerResults(entry) {
 
     const rectanglesBadge = document.createElement('span');
     rectanglesBadge.className = 'badge rectangles-badge';
-    const rectanglesCount =
-      typeof record.boxs === 'number' && Number.isFinite(record.boxs) ? record.boxs : 1;
-    rectanglesBadge.textContent = `Rectangles: ${rectanglesCount}`;
+    rectanglesBadge.textContent = `Rectangles: ${record.boxs}`;
 
     meta.append(dayBadge, nameEl, timeBadge, rectanglesBadge);
 
@@ -507,177 +492,26 @@ function renderPlayerResults(entry) {
     rank.textContent = `Rank ${record.rank}`;
 
     card.append(meta, rank);
-    playerResultsContainer.append(card);
+    fragment.append(card);
   });
+
+  playerResultsContainer.append(fragment);
 }
 
-function startCanvasAnimation() {
-  if (canvasAnimationId) {
-    cancelAnimationFrame(canvasAnimationId);
-    canvasAnimationId = null;
-  }
+// --- Utilities -----------------------------------------------------------------------------
 
-  if (canvasResizeHandler) {
-    window.removeEventListener('resize', canvasResizeHandler);
-    if (window.visualViewport) {
-      window.visualViewport.removeEventListener('resize', canvasResizeHandler);
-      window.visualViewport.removeEventListener('scroll', canvasResizeHandler);
+function resolveBoxCount(player) {
+  const rawValue = player?.boxs;
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue > 0) {
+    return Math.round(rawValue);
+  }
+  if (typeof rawValue === 'string') {
+    const parsed = Number.parseInt(rawValue, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
     }
-    canvasResizeHandler = null;
   }
-
-  if (!canvas || !canvas.getContext || !winnerTimeline.length) {
-    return;
-  }
-
-  const ctx = canvas.getContext('2d');
-  const times = winnerTimeline.map((entry) => entry.seconds).filter((value) => Number.isFinite(value));
-  const minTime = times.length ? Math.min(...times) : 0;
-  const maxTime = times.length ? Math.max(...times) : 1;
-  const dayCount = winnerTimeline.length;
-  const duration = 10000;
-  let width = canvas.clientWidth || canvas.width;
-  let height = canvas.clientHeight || canvas.height;
-  let padding = 24;
-  let stepX = 0;
-  let start = null;
-  let labelFontSize = 14;
-
-  function configureDimensions() {
-    const parentWidth = canvas.parentElement?.clientWidth || window.innerWidth || 360;
-    const styles = getComputedStyle(root);
-    const layoutMax = parseFloat(styles.getPropertyValue('--layout-max-width')) || parentWidth;
-    const viewportWidth = parseFloat(styles.getPropertyValue('--viewport-width')) || parentWidth;
-    const viewportHeight = parseFloat(styles.getPropertyValue('--viewport-height')) || window.innerHeight || 640;
-    const spacingScale = parseFloat(styles.getPropertyValue('--spacing-scale')) || 1;
-    const fontScale = parseFloat(styles.getPropertyValue('--font-scale')) || 1;
-    const maxWidth = Math.min(layoutMax, viewportWidth * 0.96);
-    const cssWidth = Math.min(parentWidth, Math.max(280, maxWidth));
-    const cssHeight = clamp(Math.round(cssWidth * 0.64), 200, Math.round(viewportHeight * 0.42));
-    const dpr = window.devicePixelRatio || 1;
-
-    canvas.style.width = `${cssWidth}px`;
-    canvas.style.height = `${cssHeight}px`;
-    canvas.width = Math.round(cssWidth * dpr);
-    canvas.height = Math.round(cssHeight * dpr);
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-    width = cssWidth;
-    height = cssHeight;
-    padding = Math.max(Math.round(18 * spacingScale), Math.round(cssWidth * 0.1));
-    stepX = dayCount > 1 ? (width - padding * 2) / (dayCount - 1) : 0;
-    labelFontSize = Math.round(clamp(14 * fontScale, 12, 18));
-  }
-
-  function mapY(seconds) {
-    if (!Number.isFinite(seconds)) {
-      return height / 2;
-    }
-    if (maxTime === minTime) {
-      return height / 2;
-    }
-    const normalized = (seconds - minTime) / (maxTime - minTime);
-    return height - padding - normalized * (height - padding * 2);
-  }
-
-  function drawFrame(timestamp) {
-    if (start === null) {
-      start = timestamp;
-    }
-    const elapsed = (timestamp - start) % duration;
-    const progress = elapsed / duration;
-
-    ctx.clearRect(0, 0, width, height);
-
-    const gradient = ctx.createLinearGradient(0, 0, width, height);
-    gradient.addColorStop(0, 'rgba(6, 200, 255, 0.35)');
-    gradient.addColorStop(1, 'rgba(6, 200, 255, 0)');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, width, height);
-
-    ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(padding, padding);
-    ctx.lineTo(padding, height - padding);
-    ctx.lineTo(width - padding, height - padding);
-    ctx.stroke();
-
-    ctx.lineWidth = 2.4;
-    ctx.strokeStyle = 'rgba(6, 200, 255, 0.9)';
-    ctx.beginPath();
-
-    winnerTimeline.forEach((entry, index) => {
-      const x = padding + index * stepX;
-      const y = mapY(entry.seconds);
-      if (index === 0) {
-        ctx.moveTo(x, y);
-      } else {
-        const visibleProgress = progress * Math.max(dayCount - 1, 1);
-        if (index - 1 <= visibleProgress) {
-          ctx.lineTo(x, y);
-        }
-      }
-    });
-
-    ctx.stroke();
-
-    const cursorProgress = progress * Math.max(dayCount - 1, 1);
-    const baseIndex = Math.floor(cursorProgress);
-    const fractional = cursorProgress - baseIndex;
-
-    const current = winnerTimeline[Math.min(baseIndex, dayCount - 1)];
-    const next = winnerTimeline[Math.min(baseIndex + 1, dayCount - 1)];
-
-    const currentX = padding + baseIndex * stepX;
-    const currentY = mapY(current.seconds);
-
-    let x = currentX;
-    let y = currentY;
-
-    if (next && baseIndex < dayCount - 1) {
-      const nextX = padding + (baseIndex + 1) * stepX;
-      const nextY = mapY(next.seconds);
-      x = currentX + (nextX - currentX) * fractional;
-      y = currentY + (nextY - currentY) * fractional;
-    }
-
-    const glow = ctx.createRadialGradient(x, y, 0, x, y, 28);
-    glow.addColorStop(0, 'rgba(6, 200, 255, 0.55)');
-    glow.addColorStop(1, 'rgba(6, 200, 255, 0)');
-    ctx.fillStyle = glow;
-    ctx.beginPath();
-    ctx.arc(x, y, 28, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.fillStyle = '#06c8ff';
-    ctx.beginPath();
-    ctx.arc(x, y, 6, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.75)';
-    ctx.font = `${labelFontSize}px Inter, sans-serif`;
-    ctx.fillText(`Day ${current.day} – ${current.name}`, padding, padding - 8);
-
-    canvasAnimationId = requestAnimationFrame(drawFrame);
-  }
-
-  canvasResizeHandler = () => {
-    if (canvasAnimationId) {
-      cancelAnimationFrame(canvasAnimationId);
-    }
-    configureDimensions();
-    start = null;
-    canvasAnimationId = requestAnimationFrame(drawFrame);
-  };
-
-  configureDimensions();
-  canvasAnimationId = requestAnimationFrame(drawFrame);
-  window.addEventListener('resize', canvasResizeHandler, { passive: true });
-  if (window.visualViewport) {
-    window.visualViewport.addEventListener('resize', canvasResizeHandler, { passive: true });
-    window.visualViewport.addEventListener('scroll', canvasResizeHandler, { passive: true });
-  }
+  return 1;
 }
 
 function parseTimeToSeconds(timeString) {
@@ -704,6 +538,8 @@ function buildInstagramLink(name) {
   return `https://instagram.com/${sanitized}`;
 }
 
+// --- Event bindings ------------------------------------------------------------------------
+
 playerSearchInput.addEventListener('change', () => updatePlayerResults());
 playerSearchInput.addEventListener('input', () => {
   if (!playerSearchInput.value) {
@@ -712,13 +548,18 @@ playerSearchInput.addEventListener('input', () => {
   }
 
   const normalized = playerSearchInput.value.trim().toLowerCase();
-  if (playerIndex.has(normalized)) {
+  ensurePlayerIndex();
+  if (state.playerIndex.has(normalized)) {
     updatePlayerResults();
   } else {
     updatePlayerResults({ silentOnNoMatch: true });
   }
 });
-sortFieldSelect.addEventListener('change', () => currentPlayer && renderPlayerResults(currentPlayer));
-sortOrderSelect.addEventListener('change', () => currentPlayer && renderPlayerResults(currentPlayer));
+
+playerSearchInput.addEventListener('focus', ensurePlayerIndex);
+sortFieldSelect.addEventListener('change', () => state.currentPlayer && renderPlayerResults(state.currentPlayer));
+sortOrderSelect.addEventListener('change', () => state.currentPlayer && renderPlayerResults(state.currentPlayer));
+
+// --- Kick everything off -------------------------------------------------------------------
 
 loadStats();

--- a/index.html
+++ b/index.html
@@ -27,42 +27,58 @@
               Here you can check your daily stats. This is just a pre-release version, so please be patient if you encounter any bugs — we’re working on fixing them soon!
             </p>
           </div>
-          <figure class="hero__visual">
-            <canvas
-              id="statsCanvas"
-              width="480"
-              height="320"
-              aria-label="Animated winner timeline"
-            ></canvas>
-            <figcaption class="hero__hint">Live winner timeline</figcaption>
-          </figure>
+          <!-- The animated canvas used to live here; we now keep the hero ultra-lightweight
+               so that first paint on low-end phones happens instantly. -->
         </div>
       </header>
 
       <nav class="quick-nav" aria-label="Phone navigation">
         <div class="quick-nav__container">
-          <button type="button" class="quick-nav__button" data-scroll-target="hero" aria-pressed="true">
-            Overview
-          </button>
-          <button type="button" class="quick-nav__button" data-scroll-target="open-stats">
+          <button
+            type="button"
+            class="quick-nav__button"
+            data-view-target="open"
+            aria-pressed="true"
+          >
             Open stats
           </button>
-          <button type="button" class="quick-nav__button" data-scroll-target="player-stats">
+          <button type="button" class="quick-nav__button" data-view-target="players" aria-pressed="false">
             Player stats
           </button>
         </div>
       </nav>
 
       <main class="main" id="content">
-        <section id="open-stats" class="panel" aria-labelledby="open-stats-title">
+        <!-- Open stats view: default screen that only renders winner previews. -->
+        <section
+          id="open-stats"
+          class="panel"
+          data-view="open"
+          aria-labelledby="open-stats-title"
+        >
           <div class="panel__header">
             <h2 id="open-stats-title" class="panel__title">Open Stats</h2>
             <span class="panel__subtitle">Tap any day to open a leaderboard</span>
           </div>
+          <p class="panel__notice" role="note">
+            ⚠️ Viewing the full leaderboard can stress older phones. Only the winner loads first;
+            use “View more” with caution.
+          </p>
+          <div class="loading-block" id="open-stats-loading" role="status" aria-live="polite">
+            <span class="spinner" aria-hidden="true"></span>
+            <span class="loading-block__label">Loading winners…</span>
+          </div>
           <div id="open-stats-grid" class="card-grid" role="list"></div>
         </section>
 
-        <section id="player-stats" class="panel" aria-labelledby="player-stats-title">
+        <!-- Player stats view: kept hidden until explicitly activated to avoid heavy work. -->
+        <section
+          id="player-stats"
+          class="panel"
+          data-view="players"
+          aria-labelledby="player-stats-title"
+          hidden
+        >
           <div class="panel__header">
             <h2 id="player-stats-title" class="panel__title">Player Stats</h2>
             <span class="panel__subtitle">Search any athlete and auto-scale their daily stats</span>


### PR DESCRIPTION
## Summary
- remove the hero canvas animation and turn the quick navigation into view toggles
- add a loading indicator, up-front warning text, and lazy-loaded day leaderboards
- defer player index construction until needed and keep only the winner rendered by default

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd7dbac480832fb5934e05fbcf7b7e