### PR TITLE
Optimize stats loading for mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -121,31 +121,29 @@ a:focus {
 
 .hero__visual {
   margin: 0;
-  padding: calc(1.2rem * var(--spacing-scale));
+  padding: calc(1.35rem * var(--spacing-scale));
   border-radius: var(--radius-lg);
   border: 1px solid rgba(56, 189, 248, 0.25);
-  background: var(--surface);
+  background: linear-gradient(145deg, rgba(14, 165, 233, 0.18), rgba(2, 6, 23, 0.85));
   box-shadow: var(--shadow-soft);
   display: grid;
-  gap: calc(0.85rem * var(--spacing-scale));
+  gap: calc(0.8rem * var(--spacing-scale));
 }
 
-.hero__visual canvas {
-  width: 100%;
-  height: auto;
-  aspect-ratio: 10 / 7;
-  display: block;
-  border-radius: var(--radius-md);
-  background: rgba(148, 163, 184, 0.08);
-  max-height: calc(var(--viewport-height, 100vh) * 0.34);
-}
-
-.hero__hint {
+.hero__visual-title {
   margin: 0;
-  font-size: calc(0.78rem * var(--font-scale));
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  font-size: clamp(calc(1.1rem * var(--font-scale)), calc((1.02rem + 0.6vw) * var(--font-scale)),
+      calc(1.4rem * var(--font-scale)));
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.hero__visual-copy {
+  margin: 0;
+  font-size: clamp(calc(0.94rem * var(--font-scale)), calc((0.9rem + 0.25vw) * var(--font-scale)),
+      calc(1.05rem * var(--font-scale)));
+  line-height: 1.6;
+  color: var(--text-secondary);
 }
 
 .quick-nav {
@@ -326,6 +324,10 @@ a:focus {
   color: var(--text-muted);
 }
 
+.winner-time {
+  font-variant-numeric: tabular-nums;
+}
+
 .winner-rectangles {
   font-variant-numeric: tabular-nums;
 }
@@ -352,6 +354,12 @@ a:focus {
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease;
   width: 100%;
+}
+
+.details-button::before {
+  content: '⚠️';
+  font-size: calc(1rem * var(--font-scale));
+  filter: drop-shadow(0 0 calc(4px * var(--spacing-scale)) rgba(234, 179, 8, 0.45));
 }
 
 .details-button::after {
@@ -540,6 +548,39 @@ a:focus {
   margin: 0;
   color: var(--text-muted);
   font-style: italic;
+}
+
+.loading-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(0.75rem * var(--spacing-scale));
+  min-height: calc(3.5rem * var(--spacing-scale));
+  padding: calc(0.9rem * var(--spacing-scale));
+  color: var(--text-secondary);
+}
+
+.loading-indicator__spinner {
+  width: calc(1.4rem * var(--spacing-scale));
+  height: calc(1.4rem * var(--spacing-scale));
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.24);
+  border-top-color: rgba(56, 189, 248, 0.85);
+  animation: spin 0.85s linear infinite;
+}
+
+.loading-indicator__text {
+  font-size: clamp(calc(0.86rem * var(--font-scale)),
+      calc((0.82rem + 0.25vw) * var(--font-scale)), calc(0.95rem * var(--font-scale)));
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .page__footer {

--- a/index.html
+++ b/index.html
@@ -27,15 +27,13 @@
               Here you can check your daily stats. This is just a pre-release version, so please be patient if you encounter any bugs — we’re working on fixing them soon!
             </p>
           </div>
-          <figure class="hero__visual">
-            <canvas
-              id="statsCanvas"
-              width="480"
-              height="320"
-              aria-label="Animated winner timeline"
-            ></canvas>
-            <figcaption class="hero__hint">Live winner timeline</figcaption>
-          </figure>
+          <section class="hero__visual" aria-label="Daily winner highlight">
+            <p class="hero__visual-title">Fastest player preview</p>
+            <p class="hero__visual-copy">
+              We now load only the champion for each day first. Tap “View full leaderboard”
+              inside a day card to load additional players when you are ready.
+            </p>
+          </section>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- replace the hero canvas animation with a lightweight mobile-friendly highlight block
- lazy load leaderboard details with a warning prompt, loading indicators, and cached winner summaries
- defer player index creation until idle time and gate search interactions until the data is ready

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dd7dbac480832fb5934e05fbcf7b7e