### PR TITLE
Optimize mobile stats loading and UX

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -121,31 +121,24 @@ a:focus {
 
 .hero__visual {
   margin: 0;
-  padding: calc(1.2rem * var(--spacing-scale));
+  padding: calc(1.6rem * var(--spacing-scale));
   border-radius: var(--radius-lg);
   border: 1px solid rgba(56, 189, 248, 0.25);
-  background: var(--surface);
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(14, 165, 233, 0.16));
   box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: calc(0.85rem * var(--spacing-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.hero__visual canvas {
-  width: 100%;
-  height: auto;
-  aspect-ratio: 10 / 7;
-  display: block;
-  border-radius: var(--radius-md);
-  background: rgba(148, 163, 184, 0.08);
-  max-height: calc(var(--viewport-height, 100vh) * 0.34);
-}
-
-.hero__hint {
+.hero__visual-text {
   margin: 0;
-  font-size: calc(0.78rem * var(--font-scale));
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  font-size: clamp(calc(1.25rem * var(--font-scale)), calc(4vw * var(--font-scale)),
+      calc(1.8rem * var(--font-scale)));
+  line-height: 1.4;
+  font-weight: 600;
+  text-align: center;
+  color: rgba(248, 250, 252, 0.85);
 }
 
 .quick-nav {
@@ -234,6 +227,10 @@ a:focus {
   box-shadow: 0 calc(18px * var(--elevation-scale)) calc(35px * var(--elevation-scale))
     rgba(8, 15, 40, 0.42);
   backdrop-filter: blur(calc(18px * var(--elevation-scale)));
+}
+
+.panel--separated {
+  margin-top: calc(2.4rem * var(--spacing-scale));
 }
 
 .panel__header {
@@ -540,6 +537,49 @@ a:focus {
   margin: 0;
   color: var(--text-muted);
   font-style: italic;
+}
+
+.loading-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(0.65rem * var(--spacing-scale));
+  padding: calc(0.9rem * var(--spacing-scale));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  background: rgba(8, 15, 35, 0.72);
+  color: var(--text-secondary);
+  font-size: calc(0.95rem * var(--font-scale));
+}
+
+.loading-indicator--inline {
+  justify-self: flex-start;
+}
+
+.loading-indicator[hidden] {
+  display: none;
+}
+
+.loading-indicator__spinner {
+  width: calc(1.25rem * var(--spacing-scale));
+  height: calc(1.25rem * var(--spacing-scale));
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.25);
+  border-top-color: rgba(14, 165, 233, 0.8);
+  animation: spin 1s linear infinite;
+}
+
+.loading-indicator__label {
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .page__footer {

--- a/data/day_winners.json
+++ b/data/day_winners.json
@@ -1,0 +1,121 @@
+{
+  "day_winners": [
+    {
+      "day": 25,
+      "winner": {
+        "rank": 1,
+        "name": "\ufeffdomisgonenow",
+        "time": "00:33.969",
+        "boxs": null
+      }
+    },
+    {
+      "day": 24,
+      "winner": {
+        "rank": 1,
+        "name": "caralooficial",
+        "time": "00:39.276",
+        "boxs": null
+      }
+    },
+    {
+      "day": 23,
+      "winner": {
+        "rank": 1,
+        "name": "jetmy_",
+        "time": "00:37.387",
+        "boxs": null
+      }
+    },
+    {
+      "day": 22,
+      "winner": {
+        "rank": 1,
+        "name": "\ufeffsbrofattii",
+        "time": "00:28.095",
+        "boxs": null
+      }
+    },
+    {
+      "day": 21,
+      "winner": {
+        "rank": 1,
+        "name": "prestonmustdie",
+        "time": "00:33.530",
+        "boxs": null
+      }
+    },
+    {
+      "day": 20,
+      "winner": {
+        "rank": 1,
+        "name": "jrxmii",
+        "time": "00:36.545",
+        "boxs": null
+      }
+    },
+    {
+      "day": 19,
+      "winner": {
+        "rank": 1,
+        "name": "mark_d.l_b",
+        "time": "00:34.847",
+        "boxs": null
+      }
+    },
+    {
+      "day": 18,
+      "winner": {
+        "rank": 1,
+        "name": "patg13654",
+        "time": "00:36.398",
+        "boxs": null
+      }
+    },
+    {
+      "day": 17,
+      "winner": {
+        "rank": 1,
+        "name": "arizcardinalsfans",
+        "time": "00:40.022",
+        "boxs": 57
+      }
+    },
+    {
+      "day": 16,
+      "winner": {
+        "rank": 1,
+        "name": "\ufefffeltrupe",
+        "time": "00:37.396",
+        "boxs": null
+      }
+    },
+    {
+      "day": 15,
+      "winner": {
+        "rank": 1,
+        "name": "\ufeffmatthewt983",
+        "time": "00:37.996",
+        "boxs": null
+      }
+    },
+    {
+      "day": 14,
+      "winner": {
+        "rank": 1,
+        "name": "chl_oe_322",
+        "time": "00:35.448",
+        "boxs": null
+      }
+    },
+    {
+      "day": 13,
+      "winner": {
+        "rank": 1,
+        "name": "vermixo",
+        "time": "00:36.723",
+        "boxs": null
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -27,15 +27,9 @@
               Here you can check your daily stats. This is just a pre-release version, so please be patient if you encounter any bugs — we’re working on fixing them soon!
             </p>
           </div>
-          <figure class="hero__visual">
-            <canvas
-              id="statsCanvas"
-              width="480"
-              height="320"
-              aria-label="Animated winner timeline"
-            ></canvas>
-            <figcaption class="hero__hint">Live winner timeline</figcaption>
-          </figure>
+          <div class="hero__visual" aria-hidden="true">
+            <p class="hero__visual-text">Fast insights without the wait.</p>
+          </div>
         </div>
       </header>
 
@@ -59,10 +53,14 @@
             <h2 id="open-stats-title" class="panel__title">Open Stats</h2>
             <span class="panel__subtitle">Tap any day to open a leaderboard</span>
           </div>
+          <div id="open-stats-loading" class="loading-indicator" role="status" aria-live="polite">
+            <span class="loading-indicator__spinner" aria-hidden="true"></span>
+            <span class="loading-indicator__label">Loading winners…</span>
+          </div>
           <div id="open-stats-grid" class="card-grid" role="list"></div>
         </section>
 
-        <section id="player-stats" class="panel" aria-labelledby="player-stats-title">
+        <section id="player-stats" class="panel panel--separated" aria-labelledby="player-stats-title">
           <div class="panel__header">
             <h2 id="player-stats-title" class="panel__title">Player Stats</h2>
             <span class="panel__subtitle">Search any athlete and auto-scale their daily stats</span>
@@ -96,6 +94,10 @@
                   <option value="desc">Descending</option>
                 </select>
               </label>
+            </div>
+            <div id="player-loading" class="loading-indicator loading-indicator--inline" role="status" aria-live="polite" hidden>
+              <span class="loading-indicator__spinner" aria-hidden="true"></span>
+              <span class="loading-indicator__label">Loading player data…</span>
             </div>
             <div id="player-results" class="player-results" aria-live="polite">
               <p class="no-results">Search for a player to see results.</p>


### PR DESCRIPTION
## Summary
- remove the heavy hero canvas animation and replace it with a lightweight headline panel
- add loading indicators plus a day_winners feed so the leaderboard only fetches detailed data on demand
- lazily load full player stats when required, warn before expanding details, and improve mobile spacing

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7dbac480832fb5934e05fbcf7b7e