### PR TITLE
Allow stats dashboard to load chunked data files

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,7 +9,20 @@
  *   4. Keeping every function small, documented, and easy to tweak.
  */
 
-const DATA_URL = 'data/day_stats.json';
+// We previously served every day in a single JSON file, but that forced us to
+// ship a very large payload even when only a handful of records changed. The
+// dashboard now looks for a series of chunked files that follow the pattern
+// `data_stats1.json`, `data_stats2.json`, … inside the `data/` directory. Each
+// chunk contains a `day_stats` array, and we stitch every chunk together at
+// runtime so the rest of the rendering logic can stay exactly the same.
+const DATA_FILE_PREFIX = 'data/data_stats';
+const DATA_FILE_SUFFIX = '.json';
+// Guard rail so a misconfigured server cannot trap us in an endless loop if it
+// keeps returning successful responses for every index.
+const MAX_DATA_FILES = 50;
+// Backwards compatibility: if no chunked files exist we still attempt to read
+// the legacy single-file endpoint so older datasets continue to work.
+const LEGACY_DATA_URL = 'data/day_stats.json';
 
 // --- DOM lookups ---------------------------------------------------------------------------
 
@@ -103,17 +116,16 @@ showPlayerIdleMessage();
 async function loadStats() {
   setOpenStatsLoading(true);
   try {
-    const response = await fetch(DATA_URL, { cache: 'no-cache' });
-    if (!response.ok) {
-      throw new Error(`Failed to load stats (${response.status})`);
+    // Pull every chunked file we can find and flatten the resulting lists. The
+    // helper takes care of falling back to the legacy single JSON file when no
+    // chunked files are present.
+    const combinedStats = await loadAllStatsChunks();
+
+    if (!combinedStats.length) {
+      throw new Error('No day stats available');
     }
 
-    const payload = await response.json();
-    if (!payload || !Array.isArray(payload.day_stats)) {
-      throw new Error('Unexpected data format');
-    }
-
-    initialiseDays(payload.day_stats);
+    initialiseDays(combinedStats);
   } catch (error) {
     console.error(error);
     openStatsGrid.innerHTML = `<p class="no-results">${error.message}. Check the JSON endpoint.</p>`;
@@ -121,6 +133,70 @@ async function loadStats() {
   } finally {
     setOpenStatsLoading(false);
   }
+}
+
+/**
+ * Load every stats chunk following the `data_statsN.json` naming convention.
+ *
+ * The user now has the freedom to split the dataset into arbitrarily sized
+ * files (for example, six days in `data_stats1.json` and seven in
+ * `data_stats2.json`). We iterate over indexes starting at 1 and stop as soon
+ * as we hit a 404, which indicates the sequence ended. The helper also falls
+ * back to the historical `day_stats.json` file when no chunked files exist so
+ * legacy deployments keep functioning without manual migration.
+ */
+async function loadAllStatsChunks() {
+  const aggregated = [];
+  let filesFound = 0;
+
+  for (let index = 1; index <= MAX_DATA_FILES; index += 1) {
+    const url = `${DATA_FILE_PREFIX}${index}${DATA_FILE_SUFFIX}`;
+
+    let response;
+    try {
+      response = await fetch(url, { cache: 'no-cache' });
+    } catch (networkError) {
+      // Surface network issues immediately because retrying would likely fail
+      // again and waste the viewer's time.
+      throw new Error(`Network error while loading ${url}`);
+    }
+
+    if (response.status === 404) {
+      // Once we encounter the first gap in the sequence we can stop scanning.
+      break;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to load ${url} (${response.status})`);
+    }
+
+    const payload = await response.json();
+    if (!payload || !Array.isArray(payload.day_stats)) {
+      throw new Error(`Unexpected data format in ${url}`);
+    }
+
+    aggregated.push(...payload.day_stats);
+    filesFound += 1;
+  }
+
+  // If the loop never found a chunked file we revert to the legacy single
+  // endpoint. This keeps older datasets functional and gives the editor time to
+  // migrate gradually.
+  if (filesFound === 0) {
+    const legacyResponse = await fetch(LEGACY_DATA_URL, { cache: 'no-cache' });
+    if (!legacyResponse.ok) {
+      throw new Error(`Failed to load stats (${legacyResponse.status})`);
+    }
+
+    const legacyPayload = await legacyResponse.json();
+    if (!legacyPayload || !Array.isArray(legacyPayload.day_stats)) {
+      throw new Error('Unexpected data format');
+    }
+
+    aggregated.push(...legacyPayload.day_stats);
+  }
+
+  return aggregated;
 }
 
 /**

--- a/data/data_stats1.json
+++ b/data/data_stats1.json
@@ -1,0 +1,344 @@
+{
+  "day_stats": [
+    {
+      "day": 13,
+      "players": [
+        {
+          "rank": 1,
+          "name": "vermixo",
+          "time": "00:36.723"
+        },
+        {
+          "rank": 2,
+          "name": "matteo.lnb09",
+          "time": "00:36.310"
+        },
+        {
+          "rank": 3,
+          "name": "mirsub_",
+          "time": "00:35.903"
+        },
+        {
+          "rank": 4,
+          "name": "samir_09116",
+          "time": "00:35.852"
+        },
+        {
+          "rank": 5,
+          "name": "testickle67",
+          "time": "00:35.451"
+        },
+        {
+          "rank": 6,
+          "name": "lth10908",
+          "time": "00:35.252"
+        },
+        {
+          "rank": 7,
+          "name": "decd_the_road",
+          "time": "00:34.858"
+        },
+        {
+          "rank": 8,
+          "name": "eli_olig",
+          "time": "00:34.736"
+        },
+        {
+          "rank": 9,
+          "name": "noahbauman24",
+          "time": "00:34.349"
+        },
+        {
+          "rank": 10,
+          "name": "dhrf1_reddy",
+          "time": "00:34.181"
+        },
+        {
+          "rank": 11,
+          "name": "__szczurq__",
+          "time": "00:33.800"
+        },
+        {
+          "rank": 12,
+          "name": "kash28111",
+          "time": "00:33.424"
+        },
+        {
+          "rank": 13,
+          "name": "ksawi.grz",
+          "time": "00:33.238"
+        },
+        {
+          "rank": 14,
+          "name": "simon__hajek",
+          "time": "00:32.915"
+        },
+        {
+          "rank": 15,
+          "name": "wtf.marley",
+          "time": "00:32.869"
+        },
+        {
+          "rank": 16,
+          "name": "finsfaroog",
+          "time": "00:32.549"
+        },
+        {
+          "rank": 17,
+          "name": "wsg_monkk",
+          "time": "00:32.549"
+        },
+        {
+          "rank": 18,
+          "name": "_mesiuhh",
+          "time": "00:32.504"
+        },
+        {
+          "rank": 19,
+          "name": "blackk_.man",
+          "time": "00:32.188"
+        },
+        {
+          "rank": 20,
+          "name": "young_pio3er",
+          "time": "00:31.831"
+        },
+        {
+          "rank": 21,
+          "name": "linneamckern",
+          "time": "00:31.610"
+        },
+        {
+          "rank": 22,
+          "name": "carcarbanks7",
+          "time": "00:31.325"
+        },
+        {
+          "rank": 23,
+          "name": "wormy_022",
+          "time": "00:31.043"
+        }
+      ]
+    },
+    {
+      "day": 14,
+      "players": [
+        {
+          "rank": 1,
+          "name": "chl_oe_322",
+          "time": "00:35.448"
+        },
+        {
+          "rank": 2,
+          "name": "itz_callum_xx",
+          "time": "00:35.044"
+        },
+        {
+          "rank": 3,
+          "name": "jackson__krn",
+          "time": "00:35.044"
+        },
+        {
+          "rank": 4,
+          "name": "puffyfromsphereguys",
+          "time": "00:35.019"
+        },
+        {
+          "rank": 5,
+          "name": "gabee.up",
+          "time": "00:34.869"
+        },
+        {
+          "rank": 6,
+          "name": "gil.martin_30",
+          "time": "00:34.473"
+        },
+        {
+          "rank": 7,
+          "name": "dieg0_rnds",
+          "time": "00:34.083"
+        },
+        {
+          "rank": 8,
+          "name": "\ufeffbananacat252",
+          "time": "00:33.698"
+        },
+        {
+          "rank": 9,
+          "name": "finneganmattingly",
+          "time": "00:33.318"
+        },
+        {
+          "rank": 10,
+          "name": "obama_wheels",
+          "time": "00:33.318"
+        },
+        {
+          "rank": 11,
+          "name": "roytargonski",
+          "time": "00:32.943"
+        },
+        {
+          "rank": 12,
+          "name": "darian_gutierrez.58",
+          "time": "00:32.757"
+        },
+        {
+          "rank": 13,
+          "name": "barbod.adi",
+          "time": "00:32.711"
+        },
+        {
+          "rank": 14,
+          "name": "slav_marian",
+          "time": "00:32.481"
+        },
+        {
+          "rank": 15,
+          "name": "aidanpatrowic",
+          "time": "00:32.390"
+        },
+        {
+          "rank": 16,
+          "name": "brock._.fxt",
+          "time": "00:32.344"
+        },
+        {
+          "rank": 17,
+          "name": "chickenk123456",
+          "time": "00:32.095"
+        },
+        {
+          "rank": 18,
+          "name": "griffin.vanzandt",
+          "time": "00:31.982"
+        },
+        {
+          "rank": 19,
+          "name": "coltrrer",
+          "time": "00:31.736"
+        },
+        {
+          "rank": 20,
+          "name": "txdw_",
+          "time": "00:31.713"
+        },
+        {
+          "rank": 21,
+          "name": "tordion_pro",
+          "time": "00:31.403"
+        },
+        {
+          "rank": 22,
+          "name": "llew_jones24",
+          "time": "00:31.381"
+        },
+        {
+          "rank": 23,
+          "name": "yhon1026",
+          "time": "00:31.053"
+        },
+        {
+          "rank": 24,
+          "name": "jackson.h82",
+          "time": "00:30.987"
+        },
+        {
+          "rank": 25,
+          "name": "sesameapplepie",
+          "time": "00:30.814"
+        },
+        {
+          "rank": 26,
+          "name": "brody_cameron3",
+          "time": "00:30.685"
+        },
+        {
+          "rank": 27,
+          "name": "deniz__gs1.9.0.5",
+          "time": "00:30.471"
+        },
+        {
+          "rank": 28,
+          "name": "mralfiem",
+          "time": "00:30.450"
+        },
+        {
+          "rank": 29,
+          "name": "square_race_2d",
+          "time": "00:30.428"
+        },
+        {
+          "rank": 30,
+          "name": "can_of_beans08",
+          "time": "00:30.111"
+        },
+        {
+          "rank": 31,
+          "name": "michaelmouse._",
+          "time": "00:29.964"
+        },
+        {
+          "rank": 32,
+          "name": "star_killer457",
+          "time": "00:29.693"
+        },
+        {
+          "rank": 33,
+          "name": "ankae.saat",
+          "time": "00:29.424"
+        },
+        {
+          "rank": 34,
+          "name": "iamnotfoomaa",
+          "time": "00:29.240"
+        },
+        {
+          "rank": 35,
+          "name": "rooti3200",
+          "time": "00:29.118"
+        },
+        {
+          "rank": 36,
+          "name": "beckett_clarke",
+          "time": "00:28.956"
+        },
+        {
+          "rank": 37,
+          "name": "wtfsilenced",
+          "time": "00:28.956"
+        },
+        {
+          "rank": 38,
+          "name": "itsurboychavez",
+          "time": "00:28.814"
+        },
+        {
+          "rank": 39,
+          "name": "imu1st",
+          "time": "00:28.774"
+        },
+        {
+          "rank": 40,
+          "name": "joshuas2410",
+          "time": "00:28.694"
+        },
+        {
+          "rank": 41,
+          "name": "j.c_stringworks",
+          "time": "00:28.634"
+        },
+        {
+          "rank": 42,
+          "name": "bstn_csn",
+          "time": "00:28.475"
+        },
+        {
+          "rank": 43,
+          "name": "idon.tknowwhati",
+          "time": "00:28.455"
+        }
+      ]
+    }
+  ]
+}

--- a/data/data_stats2.json
+++ b/data/data_stats2.json
@@ -1,0 +1,249 @@
+{
+  "day_stats": [
+    {
+      "day": 15,
+      "players": [
+        {
+          "rank": 1,
+          "name": "\ufeffmatthewt983",
+          "time": "00:37.996"
+        },
+        {
+          "rank": 2,
+          "name": "t30________",
+          "time": "00:37.644"
+        },
+        {
+          "rank": 3,
+          "name": "helawhiteboy",
+          "time": "00:37.426"
+        },
+        {
+          "rank": 4,
+          "name": "zacharykraekel",
+          "time": "00:37.166"
+        },
+        {
+          "rank": 5,
+          "name": "leander_httr",
+          "time": "00:36.887"
+        },
+        {
+          "rank": 6,
+          "name": "bethany.mawby",
+          "time": "00:36.823"
+        },
+        {
+          "rank": 7,
+          "name": "sharkjujg1",
+          "time": "00:36.548"
+        },
+        {
+          "rank": 8,
+          "name": "greengummy782",
+          "time": "00:36.338"
+        },
+        {
+          "rank": 9,
+          "name": "oscarcurran6",
+          "time": "00:36.067"
+        },
+        {
+          "rank": 10,
+          "name": "vaqgel",
+          "time": "00:36.005"
+        },
+        {
+          "rank": 11,
+          "name": "monetusapp",
+          "time": "00:35.737"
+        },
+        {
+          "rank": 12,
+          "name": "gabeh1268",
+          "time": "00:35.411"
+        },
+        {
+          "rank": 13,
+          "name": "firefist.zx",
+          "time": "00:35.330"
+        },
+        {
+          "rank": 14,
+          "name": "macegrosdeluxe",
+          "time": "00:35.128"
+        },
+        {
+          "rank": 15,
+          "name": "tomgreenkaka",
+          "time": "00:35.028"
+        },
+        {
+          "rank": 16,
+          "name": "ry2.exe",
+          "time": "00:35.008"
+        },
+        {
+          "rank": 17,
+          "name": "exxotic.marz",
+          "time": "00:34.948"
+        },
+        {
+          "rank": 18,
+          "name": "martsya03",
+          "time": "00:34.868"
+        },
+        {
+          "rank": 19,
+          "name": "jonnytb212",
+          "time": "00:34.809"
+        },
+        {
+          "rank": 20,
+          "name": "finskaie",
+          "time": "00:34.769"
+        },
+        {
+          "rank": 21,
+          "name": "ashesfrompoland",
+          "time": "00:34.690"
+        },
+        {
+          "rank": 22,
+          "name": "gb.lune",
+          "time": "00:34.670"
+        },
+        {
+          "rank": 23,
+          "name": "arthurchang53",
+          "time": "00:34.631"
+        },
+        {
+          "rank": 24,
+          "name": "meowl284",
+          "time": "00:34.552"
+        },
+        {
+          "rank": 25,
+          "name": "zahirorr",
+          "time": "00:34.493"
+        },
+        {
+          "rank": 26,
+          "name": "venja0_0",
+          "time": "00:34.434"
+        },
+        {
+          "rank": 27,
+          "name": "adityaprivate___",
+          "time": "00:34.375"
+        },
+        {
+          "rank": 28,
+          "name": "loganstu1",
+          "time": "00:34.356"
+        },
+        {
+          "rank": 29,
+          "name": "connor.f707",
+          "time": "00:34.356"
+        },
+        {
+          "rank": 30,
+          "name": "timjnt15",
+          "time": "00:34.356"
+        },
+        {
+          "rank": 31,
+          "name": "vaughn.32",
+          "time": "00:34.045"
+        },
+        {
+          "rank": 32,
+          "name": "jacknaroian",
+          "time": "00:33.967"
+        },
+        {
+          "rank": 33,
+          "name": "merteyappt",
+          "time": "00:33.967"
+        },
+        {
+          "rank": 34,
+          "name": "mikeysthebestest",
+          "time": "00:33.660"
+        },
+        {
+          "rank": 35,
+          "name": "oh.neeko",
+          "time": "00:33.508"
+        },
+        {
+          "rank": 36,
+          "name": "epng.45",
+          "time": "00:33.413"
+        },
+        {
+          "rank": 37,
+          "name": "tchoupi253",
+          "time": "00:33.357"
+        },
+        {
+          "rank": 38,
+          "name": "kalebkvarnberg",
+          "time": "00:33.094"
+        },
+        {
+          "rank": 39,
+          "name": "ali_tur6969",
+          "time": "00:33.075"
+        },
+        {
+          "rank": 40,
+          "name": "degs5",
+          "time": "00:33.056"
+        },
+        {
+          "rank": 41,
+          "name": "alby._sa",
+          "time": "00:32.777"
+        },
+        {
+          "rank": 42,
+          "name": "grzess8888",
+          "time": "00:32.593"
+        },
+        {
+          "rank": 43,
+          "name": "jake_kenjesky",
+          "time": "00:32.593"
+        },
+        {
+          "rank": 44,
+          "name": "andreiv_217",
+          "time": "00:32.574"
+        },
+        {
+          "rank": 45,
+          "name": "bragebru",
+          "time": "00:32.519"
+        },
+        {
+          "rank": 46,
+          "name": "heitorzindosemaforo",
+          "time": "00:32.464"
+        },
+        {
+          "rank": 47,
+          "name": "king_sorrow.c",
+          "time": "00:32.428"
+        },
+        {
+          "rank": 48,
+          "name": "louzestra",
+          "time": "00:32.409"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add support for loading stats from sequentially numbered `data_statsN.json` files with a legacy fallback
- document the new loader logic heavily and keep the existing rendering flow unchanged
- split the sample dataset into `data_stats1.json` and `data_stats2.json`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e18f977c5c832f838749b912203ca3