### PR TITLE
Add Extra Box quick nav button

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -603,6 +603,54 @@ a:focus {
   color: var(--accent-strong);
 }
 
+/*
+ * Extra Box shortcut styling -------------------------------------------------
+ * The new button needs a wiggle animation and a badge to highlight that it is
+ * fresh. Every declaration is documented so future adjustments stay simple.
+ */
+.quick-nav__button--new {
+  position: relative; /* Required so the badge can be absolutely positioned. */
+  overflow: hidden; /* Keeps the badge glow from overflowing the pill shape. */
+  animation: quick-nav-wiggle 1800ms ease-in-out infinite; /* Gentle attention grab. */
+}
+
+/* Dedicated badge that spells NEW in a small pill. */
+.quick-nav__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.5rem;
+  margin-left: 0.25rem;
+  border-radius: 999px;
+  font-size: 0.65em;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f172a;
+  background: linear-gradient(135deg, #facc15, #f97316);
+  box-shadow: 0 0.4rem 1rem rgba(250, 204, 21, 0.35);
+}
+
+/* Subtle wobble so the "NEW" button feels alive without being distracting. */
+@keyframes quick-nav-wiggle {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  15% {
+    transform: rotate(-2deg) scale(1.02);
+  }
+  30% {
+    transform: rotate(2deg) scale(1.02);
+  }
+  45% {
+    transform: rotate(-1.5deg) scale(1.01);
+  }
+  60% {
+    transform: rotate(1.5deg) scale(1.01);
+  }
+}
+
 .rank-badge {
   justify-self: start;
   background: rgba(13, 148, 136, 0.2);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -89,8 +89,15 @@ showView('open');
 quickNavButtons.forEach((button) => {
   button.addEventListener('click', () => {
     const target = button.dataset.viewTarget;
+    const externalUrl = button.dataset.url;
+
     if (target) {
+      // Standard quick-nav behaviour: swap the active panel inside the page.
       showView(target);
+    } else if (externalUrl) {
+      // Extra Box shortcut: open the configured URL in a new tab/window without
+      // blocking the main thread. `noopener` keeps the original page secure.
+      window.open(externalUrl, '_blank', 'noopener');
     }
   });
 });

--- a/index.html
+++ b/index.html
@@ -45,6 +45,16 @@
           <button type="button" class="quick-nav__button" data-view-target="players" aria-pressed="false">
             Player stats
           </button>
+          <!-- Extra Box: external quick link with a "NEW" badge and playful animation -->
+          <button
+            type="button"
+            class="quick-nav__button quick-nav__button--new"
+            data-url="https://example.com/extra-box"
+            aria-pressed="false"
+          >
+            Extra Box
+            <span class="quick-nav__badge" aria-hidden="true">NEW</span>
+          </button>
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary
- add an Extra Box entry to the quick navigation with a NEW badge
- style the button with a gentle wiggle animation to highlight its novelty
- allow quick navigation buttons to open external URLs when configured

## Testing
- Manual QA


------
https://chatgpt.com/codex/tasks/task_e_68e2afd4b468832f9cb73e5415ae8cc2