### PR TITLE
Add animated support callout with Buy Me a Coffee widget

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -119,6 +119,82 @@ a:focus {
   color: var(--text-secondary);
 }
 
+/*
+ * Support callout styles -----------------------------------------------------
+ * The Buy Me a Coffee widget drops its own markup, but wrapping it in a styled
+ * container lets us animate the entire block and keep visual consistency with
+ * the rest of the hero section.
+ */
+.support-callout {
+  position: relative;
+  margin: calc(1.6rem * var(--spacing-scale)) 0 0;
+  padding: calc(1.25rem * var(--spacing-scale));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: linear-gradient(135deg, rgba(51, 148, 147, 0.16), rgba(14, 165, 233, 0.08));
+  box-shadow: 0 calc(22px * var(--elevation-scale)) calc(42px * var(--elevation-scale)) rgba(2, 6, 23, 0.45);
+  overflow: hidden;
+  transform: translateY(32px);
+  opacity: 0;
+  transition: transform 420ms cubic-bezier(0.16, 1, 0.3, 1), opacity 420ms ease;
+}
+
+/* Decorative glow that fades in when the callout becomes visible. */
+.support-callout::before {
+  content: '';
+  position: absolute;
+  inset: -35% -45% auto;
+  height: 120%;
+  background: radial-gradient(circle at top, rgba(255, 221, 0, 0.55), transparent 60%);
+  opacity: 0;
+  transition: opacity 600ms ease;
+  pointer-events: none;
+}
+
+/* Long copy stays friendly and legible. */
+.support-callout__message {
+  margin: 0 0 calc(0.9rem * var(--spacing-scale));
+  font-size: calc(0.95rem * var(--font-scale));
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+/* Wrapper keeps the external button centered without touching its internals. */
+.support-callout__button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/*
+ * When the IntersectionObserver in app.js flags the component as visible we
+ * pop the callout upwards and fade in the decorative glow.
+ */
+.support-callout--visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.support-callout--visible::before {
+  opacity: 1;
+}
+
+/* A playful pulse applied to the widget after it appears, encouraging clicks
+   without being distracting. */
+@keyframes support-callout-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.04);
+  }
+}
+
+.support-callout--visible [data-animate='pulse'] {
+  animation: support-callout-pulse 3s ease-in-out 0.6s infinite;
+}
+
 .hero__visual {
   margin: 0;
   padding: calc(1.2rem * var(--spacing-scale));

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -39,6 +39,7 @@ const sortFieldSelect = document.getElementById('sort-field');
 const sortOrderSelect = document.getElementById('sort-order');
 const quickNavButtons = Array.from(document.querySelectorAll('.quick-nav__button'));
 const viewSections = Array.from(document.querySelectorAll('[data-view]'));
+const supportCallout = document.getElementById('support-cta');
 
 // --- Shared state --------------------------------------------------------------------------
 
@@ -135,6 +136,30 @@ function showPlayerIdleMessage() {
 showPlayerIdleMessage();
 // Disable the search controls until we know whether the underlying data exists.
 setPlayerControlsDisabled(true);
+
+// --- Support widget animation --------------------------------------------------------------
+
+if (supportCallout) {
+  // IntersectionObserver keeps the animation inexpensive: the widget only starts
+  // animating when the user actually scrolls it into view. This avoids running
+  // continuous CSS animations off-screen, which would waste GPU cycles.
+  const revealSupportCallout = (entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        // Toggle the helper class consumed by styles.css so the block slides
+        // into view and triggers the gentle pulse on the embedded button.
+        supportCallout.classList.add('support-callout--visible');
+        observer.disconnect();
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(revealSupportCallout, {
+    threshold: 0.35,
+  });
+
+  observer.observe(supportCallout);
+}
 
 // --- Data loading --------------------------------------------------------------------------
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,31 @@
             <p class="hero__description">
               Here you can check your daily stats. This is just a pre-release version, so please be patient if you encounter any bugs — we’re working on fixing them soon!
             </p>
+            <!-- Support widget container: keeps the Buy Me a Coffee button near the hero copy
+                 so followers can back the project right after understanding what the page offers. -->
+            <aside class="support-callout" id="support-cta" aria-label="Support the creator">
+              <!-- A short pitch reinforces why the button exists without feeling spammy. -->
+              <p class="support-callout__message">
+                Enjoying the daily breakdowns? Fuel the next batch of videos and live breakdowns with a quick coffee!
+              </p>
+              <!-- Script from Buy Me a Coffee. We embed it directly inside the callout so the
+                   generated button inherits our layout styles. The external script paints
+                   the interactive button in place. -->
+              <div class="support-callout__button" data-animate="pulse">
+                <script
+                  type="text/javascript"
+                  src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+                  data-name="bmc-button"
+                  data-slug="follow_to_enter_the_game"
+                  data-color="#339493"
+                  data-font="Cookie"
+                  data-text="Support my videos"
+                  data-outline-color="#ffffff"
+                  data-font-color="#ffffff"
+                  data-coffee-color="#FFDD00"
+                ></script>
+              </div>
+            </aside>
           </div>
           <!-- The animated canvas used to live here; we now keep the hero ultra-lightweight
                so that first paint on low-end phones happens instantly. -->


### PR DESCRIPTION
## Summary
- embed the Buy Me a Coffee widget within the hero and add explanatory copy
- style the support callout with gradient, glow, and pulse animation treatments
- trigger the animation via an IntersectionObserver when the widget enters view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690138543248832fa698274bec958f2b