### PR TITLE
Update stats loading to use CSV and SQLite sources

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,11 @@
-const DATA_URL = 'data/day_stats.json';
+// Endpoint configuration
+// Winner stats now live in a lightweight JSON file that only includes the daily winner
+// and aggregate player count. Player stats are sourced from CSV lists and segmented
+// SQLite databases hosted externally.
+const WINNER_DATA_URL = 'data/winner.json';
+const PLAYER_LIST_URL = 'https://ball-crusher.github.io/Website/data/liste.csv';
+const SQLITE_LINKS_URL = 'https://ball-crusher.github.io/Website/data/players_sqlite_links.csv';
+const SQLITE_CHUNK_SIZE = 7000;
 
 const root = document.documentElement;
 const openStatsGrid = document.getElementById('open-stats-grid');
@@ -10,10 +17,14 @@ const sortOrderSelect = document.getElementById('sort-order');
 const canvas = document.getElementById('statsCanvas');
 
 let playerIndex = new Map();
+let playerList = [];
+let sqliteLinks = new Map();
+let sqliteDatabaseCache = new Map();
 let currentPlayer = null;
 let winnerTimeline = [];
 let canvasAnimationId = null;
 let canvasResizeHandler = null;
+let sqlJsPromise = null;
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
@@ -47,46 +58,38 @@ window.addEventListener('orientationchange', () => {
   }
 });
 
-async function loadStats() {
+async function initializeApp() {
   try {
-    const response = await fetch(DATA_URL, { cache: 'no-cache' });
-    if (!response.ok) {
-      throw new Error(`Failed to load stats (${response.status})`);
+    // We bootstrap two independent data flows:
+    // 1) Winners for the open stats grid and canvas animation.
+    // 2) Player metadata (CSV + SQLite link map) for targeted player lookups.
+    const [winners] = await Promise.all([loadWinnerStats(), loadPlayerSources()]);
+
+    if (Array.isArray(winners)) {
+      const sortedDays = [...winners].sort((a, b) => b.day - a.day);
+      winnerTimeline = buildWinnerTimeline(sortedDays);
+      renderOpenStats(sortedDays);
+      startCanvasAnimation();
     }
-    const data = await response.json();
-    if (!data || !Array.isArray(data.day_stats)) {
-      throw new Error('Unexpected data format');
-    }
-    initialize(data.day_stats);
   } catch (error) {
+    // A single failure should be surfaced to both panels because the page is mostly data-driven.
     console.error(error);
     openStatsGrid.innerHTML = `<p class="no-results">${error.message}. Check the JSON endpoint.</p>`;
     playerResultsContainer.innerHTML = `<p class="no-results">${error.message}. Player search unavailable.</p>`;
   }
 }
 
-function initialize(dayStats) {
-  const sortedDays = [...dayStats].sort((a, b) => b.day - a.day);
-  winnerTimeline = buildWinnerTimeline(sortedDays);
-  renderOpenStats(sortedDays);
-  buildPlayerIndex(sortedDays);
-  populatePlayerSuggestions();
-  startCanvasAnimation();
-}
-
 function buildWinnerTimeline(days) {
+  // The winner JSON already contains the daily champion. We only need to
+  // normalize the values and keep the list chronological for the canvas.
   return days
-    .map((day) => {
-      const winner = [...day.players].sort((a, b) => a.rank - b.rank)[0];
-      if (!winner) return null;
-      return {
-        day: day.day,
-        name: winner.name,
-        time: winner.time,
-        seconds: parseTimeToSeconds(winner.time),
-      };
-    })
-    .filter(Boolean)
+    .map((day) => ({
+      day: day.day,
+      name: day.name,
+      time: day.time,
+      seconds: parseTimeToSeconds(day.time),
+    }))
+    .filter((entry) => Number.isFinite(entry.seconds))
     .sort((a, b) => a.day - b.day);
 }
 
@@ -111,115 +114,92 @@ function renderOpenStats(days) {
 
     const winnerInfo = document.createElement('div');
     winnerInfo.className = 'winner';
-    const topPlayer = [...day.players].sort((a, b) => a.rank - b.rank)[0];
     const winnerLink = document.createElement('a');
-    winnerLink.href = buildInstagramLink(topPlayer?.name);
+    winnerLink.href = buildInstagramLink(day?.name);
     winnerLink.target = '_blank';
     winnerLink.rel = 'noopener noreferrer';
-    winnerLink.textContent = topPlayer ? topPlayer.name : '—';
+    winnerLink.textContent = day?.name ?? '—';
 
     const winnerLabel = document.createElement('span');
     winnerLabel.textContent = 'Daily winner';
     winnerInfo.append(winnerLink, winnerLabel);
 
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'details-button';
-    button.textContent = 'More details';
-    button.setAttribute('aria-expanded', 'false');
+    const meta = document.createElement('div');
+    meta.className = 'winner-meta';
+    meta.innerHTML = `
+      <span class="time">Time: ${day.time || '—'}</span>
+      <span class="players">Players: ${day.players?.toLocaleString?.() || '—'}</span>
+    `;
 
-    header.append(label, winnerInfo, button);
-
-    const collapse = document.createElement('div');
-    collapse.className = 'collapse';
-    const collapseId = `day-${day.day}-details`;
-    collapse.id = collapseId;
-    collapse.hidden = true;
-    button.setAttribute('aria-controls', collapseId);
-
-    const list = document.createElement('ul');
-    list.className = 'player-list';
-
-    [...day.players]
-      .sort((a, b) => a.rank - b.rank)
-      .forEach((player) => {
-        const item = document.createElement('li');
-
-        const left = document.createElement('div');
-        left.className = 'player-name';
-        left.innerHTML = `<strong>${ordinal(player.rank)}</strong> &nbsp; <a href="${buildInstagramLink(
-          player.name
-        )}" target="_blank" rel="noopener noreferrer">${player.name}</a>`;
-
-        const right = document.createElement('span');
-        right.className = 'player-time';
-        right.textContent = `Time: ${player.time}`;
-
-        item.append(left, right);
-        list.append(item);
-      });
-
-    collapse.append(list);
-
-    button.addEventListener('click', () => {
-      const isOpen = collapse.classList.toggle('open');
-      collapse.hidden = !isOpen;
-      button.setAttribute('aria-expanded', String(isOpen));
-      button.textContent = isOpen ? 'Hide details' : 'More details';
-
-      if (isOpen) {
-        document.querySelectorAll('.collapse.open').forEach((openSection) => {
-          if (openSection === collapse) return;
-          openSection.classList.remove('open');
-          openSection.hidden = true;
-          const toggle = openSection.previousElementSibling?.querySelector?.('.details-button');
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'false');
-            toggle.textContent = 'More details';
-          }
-        });
-
-        if (typeof collapse.scrollIntoView === 'function') {
-          requestAnimationFrame(() => {
-            collapse.scrollIntoView({ block: 'start', behavior: 'smooth' });
-          });
-        }
-      }
-    });
-
-    card.append(header, collapse);
+    header.append(label, winnerInfo, meta);
+    card.append(header);
     openStatsGrid.append(card);
   });
 }
 
-function buildPlayerIndex(days) {
-  playerIndex = new Map();
+async function loadWinnerStats() {
+  // Load the condensed winner feed that powers the Open Stats panel.
+  const response = await fetch(WINNER_DATA_URL, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Failed to load winner stats (${response.status})`);
+  }
 
-  days.forEach((day) => {
-    day.players.forEach((player) => {
-      const key = player.name.trim().toLowerCase();
-      if (!playerIndex.has(key)) {
-        playerIndex.set(key, {
-          name: player.name,
-          records: [],
-        });
-      }
-      const entry = playerIndex.get(key);
-      entry.records.push({
-        day: day.day,
-        rank: player.rank,
-        time: player.time,
-        seconds: parseTimeToSeconds(player.time),
-      });
-    });
+  const data = await response.json();
+  if (!data || !Array.isArray(data.day_stats)) {
+    throw new Error('Unexpected winner data format');
+  }
+
+  return data.day_stats;
+}
+
+async function loadPlayerSources() {
+  // Player search needs two independent lookup tables: the global player list
+  // (for position-based chunking) and the SQLite link map (for remote DB fetches).
+  const [names, links] = await Promise.all([fetchPlayerList(), fetchSqliteLinks()]);
+  playerList = names;
+  sqliteLinks = links;
+  populatePlayerSuggestions();
+  return names;
+}
+
+async function fetchPlayerList() {
+  const response = await fetch(PLAYER_LIST_URL, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Failed to load player list (${response.status})`);
+  }
+
+  const csv = await response.text();
+  return csv
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((name) => name.replace(/^\uFEFF/, ''));
+}
+
+async function fetchSqliteLinks() {
+  const response = await fetch(SQLITE_LINKS_URL, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Failed to load SQLite link map (${response.status})`);
+  }
+
+  const csv = await response.text();
+  const lines = csv.split(/\r?\n/).filter(Boolean);
+  const map = new Map();
+
+  lines.slice(1).forEach((line) => {
+    const [filename, url] = line.split(',');
+    if (filename && url) {
+      map.set(filename.trim(), url.trim());
+    }
   });
+
+  return map;
 }
 
 function populatePlayerSuggestions() {
+  // Suggestions rely on the CSV list rather than preloaded stats to keep the page light.
   playerSuggestions.innerHTML = '';
-  const sortedPlayers = Array.from(playerIndex.values())
-    .map((entry) => entry.name)
-    .sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
+  const sortedPlayers = [...playerList].sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
 
   sortedPlayers.forEach((name) => {
     const option = document.createElement('option');
@@ -228,7 +208,7 @@ function populatePlayerSuggestions() {
   });
 }
 
-function updatePlayerResults(options = {}) {
+async function updatePlayerResults(options = {}) {
   const { silentOnNoMatch = false } = options;
   const query = playerSearchInput.value.trim();
   if (!query) {
@@ -240,14 +220,9 @@ function updatePlayerResults(options = {}) {
   const normalized = query.toLowerCase();
   let entry = playerIndex.get(normalized);
 
-  if (!entry && normalized.length >= 2) {
-    const partialMatches = Array.from(playerIndex.entries())
-      .map(([key, value]) => ({ key, value }))
-      .filter(({ key, value }) => value.name.toLowerCase().includes(normalized));
-
-    if (partialMatches.length === 1) {
-      entry = partialMatches[0].value;
-    }
+  if (!entry) {
+    playerResultsContainer.innerHTML = '<p class="no-results">Loading player data…</p>';
+    entry = await fetchPlayerFromSources(normalized);
   }
 
   if (!entry) {
@@ -305,6 +280,131 @@ function renderPlayerResults(entry) {
   if (!sortedRecords.length) {
     playerResultsContainer.innerHTML = '<p class="no-results">No stats available.</p>';
   }
+}
+
+async function fetchPlayerFromSources(normalizedName) {
+  // Determine the candidate chunk based on the CSV position and then walk
+  // outward to neighboring chunks until we either find the player or run
+  // out of available SQLite files.
+  const position = findPlayerPosition(normalizedName);
+  if (position < 0) {
+    return null;
+  }
+
+  const baseChunk = deriveChunkNumber(position);
+  const offsets = buildChunkOffsets(sqliteLinks.size || 12);
+
+  for (const offset of offsets) {
+    const chunkNumber = baseChunk + offset;
+    if (chunkNumber < 1) continue;
+
+    const entry = await fetchPlayerFromChunk(chunkNumber, normalizedName);
+    if (entry) {
+      playerIndex.set(normalizedName, entry);
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+function findPlayerPosition(normalizedName) {
+  // Names come from the CSV list, so we can simply search the array once.
+  return playerList.findIndex((name) => name.trim().toLowerCase() === normalizedName);
+}
+
+function deriveChunkNumber(position) {
+  // Divide by 7000, round down, and use the resulting number as the chunk suffix.
+  // We clamp to a minimum of 1 because the file set starts at players_1.sqlite.
+  return Math.max(1, Math.floor(position / SQLITE_CHUNK_SIZE));
+}
+
+function buildChunkOffsets(limit) {
+  // Generate a symmetrical sequence: [0, 1, -1, 2, -2, ...]
+  const offsets = [0];
+  for (let i = 1; i <= limit; i += 1) {
+    offsets.push(i, -i);
+  }
+  return offsets;
+}
+
+async function fetchPlayerFromChunk(chunkNumber, normalizedName) {
+  const db = await fetchSqliteDatabase(chunkNumber);
+  if (!db) return null;
+
+  await ensureSqlJs();
+  const statement = db.prepare('SELECT username, data FROM players WHERE lower(username) = ?');
+  statement.bind([normalizedName]);
+
+  let entry = null;
+  if (statement.step()) {
+    const row = statement.getAsObject();
+    entry = normalizePlayerEntry(row.username, row.data);
+  }
+
+  statement.free?.();
+  return entry;
+}
+
+async function ensureSqlJs() {
+  // Lazy-load sql.js from a CDN and cache the initialized module to avoid
+  // repeated network traffic. The locateFile hook ensures the WASM binary
+  // resolves from the same CDN path.
+  if (!sqlJsPromise) {
+    sqlJsPromise = import('https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js').then((module) => {
+      const initSqlJs = module.default;
+      return initSqlJs({ locateFile: (file) => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/${file}` });
+    });
+  }
+  return sqlJsPromise;
+}
+
+async function fetchSqliteDatabase(chunkNumber) {
+  const filename = `players_${chunkNumber}.sqlite`;
+  if (sqliteDatabaseCache.has(filename)) {
+    return sqliteDatabaseCache.get(filename);
+  }
+
+  const url = sqliteLinks.get(filename);
+  if (!url) {
+    return null;
+  }
+
+  const response = await fetch(url, { cache: 'no-cache' });
+  if (!response.ok) {
+    console.warn(`Failed to fetch ${filename} (${response.status})`);
+    return null;
+  }
+
+  const buffer = await response.arrayBuffer();
+  const SQL = await ensureSqlJs();
+  const database = new SQL.Database(new Uint8Array(buffer));
+  sqliteDatabaseCache.set(filename, database);
+  return database;
+}
+
+function normalizePlayerEntry(username, rawData) {
+  // SQLite rows store JSON as text; we transform it into the structure the UI expects.
+  let parsed = [];
+  try {
+    parsed = JSON.parse(typeof rawData === 'string' ? rawData : rawData?.data ?? '[]');
+  } catch (error) {
+    console.warn('Failed to parse player data', error);
+  }
+
+  const records = Array.isArray(parsed)
+    ? parsed.map((item) => ({
+        day: item.day,
+        rank: item.rank,
+        time: item.time,
+        seconds: parseTimeToSeconds(item.time),
+      }))
+    : [];
+
+  return {
+    name: username,
+    records,
+  };
 }
 
 function startCanvasAnimation() {
@@ -488,21 +588,26 @@ function buildInstagramLink(name) {
   return `https://instagram.com/${sanitized}`;
 }
 
-playerSearchInput.addEventListener('change', () => updatePlayerResults());
+playerSearchInput.addEventListener('change', () => {
+  // Fire-and-forget because updatePlayerResults handles its own UI state.
+  void updatePlayerResults();
+});
+
 playerSearchInput.addEventListener('input', () => {
   if (!playerSearchInput.value) {
-    updatePlayerResults();
+    void updatePlayerResults();
     return;
   }
 
   const normalized = playerSearchInput.value.trim().toLowerCase();
   if (playerIndex.has(normalized)) {
-    updatePlayerResults();
+    void updatePlayerResults();
   } else {
-    updatePlayerResults({ silentOnNoMatch: true });
+    void updatePlayerResults({ silentOnNoMatch: true });
   }
 });
+
 sortFieldSelect.addEventListener('change', () => currentPlayer && renderPlayerResults(currentPlayer));
 sortOrderSelect.addEventListener('change', () => currentPlayer && renderPlayerResults(currentPlayer));
 
-loadStats();
+initializeApp();


### PR DESCRIPTION
## Summary
- switch Open Stats to read winners from the new `winner.json` feed and keep the canvas timeline in sync
- load player search metadata from the remote CSV list and SQLite link map with detailed inline comments
- fetch player records on demand from segmented SQLite databases using sql.js and show them in the existing UI

## Testing
- node -c assets/js/app.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d8fa1e74832f950c06eb409a6b41)